### PR TITLE
gitignore additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ lib*.pc
 /Debug/
 /Release/
 /tmp_install/
+/build/
+/.idea/


### PR DESCRIPTION
CLion's hidden folder and the `/build` directory.