### PR TITLE
Update TScout markers.

### DIFF
--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -2200,7 +2200,7 @@ ExecAgg(PlanState *pstate)
   result = _ExecAgg(pstate);
 
   TS_MARKER(nodeAgg_ExecAgg_end);
-  TS_FEATURES_MARKER(nodeAgg_ExecAgg_features, pstate);
+  TS_FEATURES_MARKER(nodeAgg_ExecAgg_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -2200,7 +2200,7 @@ ExecAgg(PlanState *pstate)
   result = _ExecAgg(pstate);
 
   TS_MARKER(nodeAgg_ExecAgg_end);
-  TS_FEATURES_MARKER(nodeAgg_ExecAgg_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeAgg_ExecAgg_features, castNode(AggState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -2197,7 +2197,7 @@ ExecAgg(PlanState *pstate)
   result = _ExecAgg(pstate);
 
   TS_MARKER(nodeAgg_ExecAgg_end);
-  TS_MARKER(nodeAgg_ExecAgg_features);
+  TS_FEATURES_MARKER(nodeAgg_ExecAgg_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -2191,7 +2191,10 @@ _ExecAgg(PlanState *pstate)
 static TupleTableSlot *
 ExecAgg(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeAgg_ExecAgg_begin);
 
   result = _ExecAgg(pstate);

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -395,7 +395,7 @@ ExecAppend(PlanState *pstate)
   result = _ExecAppend(pstate);
 
   TS_MARKER(nodeAppend_ExecAppend_end);
-  TS_FEATURES_MARKER(nodeAppend_ExecAppend_features, pstate);
+  TS_FEATURES_MARKER(nodeAppend_ExecAppend_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -392,7 +392,7 @@ ExecAppend(PlanState *pstate)
   result = _ExecAppend(pstate);
 
   TS_MARKER(nodeAppend_ExecAppend_end);
-  TS_MARKER(nodeAppend_ExecAppend_features);
+  TS_FEATURES_MARKER(nodeAppend_ExecAppend_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -395,7 +395,7 @@ ExecAppend(PlanState *pstate)
   result = _ExecAppend(pstate);
 
   TS_MARKER(nodeAppend_ExecAppend_end);
-  TS_FEATURES_MARKER(nodeAppend_ExecAppend_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeAppend_ExecAppend_features, castNode(AppendState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -386,7 +386,10 @@ _ExecAppend(PlanState *pstate)
 static TupleTableSlot *
 ExecAppend(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeAppend_ExecAppend_begin);
 
   result = _ExecAppend(pstate);

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -170,7 +170,10 @@ _ExecCteScan(PlanState *pstate)
 static TupleTableSlot *
 ExecCteScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeCtescan_ExecCteScan_begin);
 
   result = _ExecCteScan(pstate);

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -179,7 +179,7 @@ ExecCteScan(PlanState *pstate)
   result = _ExecCteScan(pstate);
 
   TS_MARKER(nodeCtescan_ExecCteScan_end);
-  TS_FEATURES_MARKER(nodeCtescan_ExecCteScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeCtescan_ExecCteScan_features, castNode(CteScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -179,7 +179,7 @@ ExecCteScan(PlanState *pstate)
   result = _ExecCteScan(pstate);
 
   TS_MARKER(nodeCtescan_ExecCteScan_end);
-  TS_FEATURES_MARKER(nodeCtescan_ExecCteScan_features, pstate);
+  TS_FEATURES_MARKER(nodeCtescan_ExecCteScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -176,7 +176,7 @@ ExecCteScan(PlanState *pstate)
   result = _ExecCteScan(pstate);
 
   TS_MARKER(nodeCtescan_ExecCteScan_end);
-  TS_MARKER(nodeCtescan_ExecCteScan_features);
+  TS_FEATURES_MARKER(nodeCtescan_ExecCteScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -119,7 +119,10 @@ _ExecCustomScan(PlanState *pstate)
 static TupleTableSlot *
 ExecCustomScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeCustom_ExecCustomScan_begin);
 
   result = _ExecCustomScan(pstate);

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -125,7 +125,7 @@ ExecCustomScan(PlanState *pstate)
   result = _ExecCustomScan(pstate);
 
   TS_MARKER(nodeCustom_ExecCustomScan_end);
-  TS_MARKER(nodeCustom_ExecCustomScan_features);
+  TS_FEATURES_MARKER(nodeCustom_ExecCustomScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -128,7 +128,7 @@ ExecCustomScan(PlanState *pstate)
   result = _ExecCustomScan(pstate);
 
   TS_MARKER(nodeCustom_ExecCustomScan_end);
-  TS_FEATURES_MARKER(nodeCustom_ExecCustomScan_features, pstate);
+  TS_FEATURES_MARKER(nodeCustom_ExecCustomScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -128,7 +128,7 @@ ExecCustomScan(PlanState *pstate)
   result = _ExecCustomScan(pstate);
 
   TS_MARKER(nodeCustom_ExecCustomScan_end);
-  TS_FEATURES_MARKER(nodeCustom_ExecCustomScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeCustom_ExecCustomScan_features, castNode(CustomScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -131,7 +131,10 @@ _ExecForeignScan(PlanState *pstate)
 static TupleTableSlot *
 ExecForeignScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeForeignscan_ExecForeignScan_begin);
 
   result = _ExecForeignScan(pstate);

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -140,7 +140,7 @@ ExecForeignScan(PlanState *pstate)
   result = _ExecForeignScan(pstate);
 
   TS_MARKER(nodeForeignscan_ExecForeignScan_end);
-  TS_FEATURES_MARKER(nodeForeignscan_ExecForeignScan_features, pstate);
+  TS_FEATURES_MARKER(nodeForeignscan_ExecForeignScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -137,7 +137,7 @@ ExecForeignScan(PlanState *pstate)
   result = _ExecForeignScan(pstate);
 
   TS_MARKER(nodeForeignscan_ExecForeignScan_end);
-  TS_MARKER(nodeForeignscan_ExecForeignScan_features);
+  TS_FEATURES_MARKER(nodeForeignscan_ExecForeignScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -140,7 +140,7 @@ ExecForeignScan(PlanState *pstate)
   result = _ExecForeignScan(pstate);
 
   TS_MARKER(nodeForeignscan_ExecForeignScan_end);
-  TS_FEATURES_MARKER(nodeForeignscan_ExecForeignScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeForeignscan_ExecForeignScan_features, castNode(ForeignScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -282,7 +282,7 @@ ExecFunctionScan(PlanState *pstate)
   result = _ExecFunctionScan(pstate);
 
   TS_MARKER(nodeFunctionscan_ExecFunctionScan_end);
-  TS_MARKER(nodeFunctionscan_ExecFunctionScan_features);
+  TS_FEATURES_MARKER(nodeFunctionscan_ExecFunctionScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -285,7 +285,7 @@ ExecFunctionScan(PlanState *pstate)
   result = _ExecFunctionScan(pstate);
 
   TS_MARKER(nodeFunctionscan_ExecFunctionScan_end);
-  TS_FEATURES_MARKER(nodeFunctionscan_ExecFunctionScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeFunctionscan_ExecFunctionScan_features, castNode(FunctionScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -276,7 +276,10 @@ _ExecFunctionScan(PlanState *pstate)
 static TupleTableSlot *
 ExecFunctionScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeFunctionscan_ExecFunctionScan_begin);
 
   result = _ExecFunctionScan(pstate);

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -285,7 +285,7 @@ ExecFunctionScan(PlanState *pstate)
   result = _ExecFunctionScan(pstate);
 
   TS_MARKER(nodeFunctionscan_ExecFunctionScan_end);
-  TS_FEATURES_MARKER(nodeFunctionscan_ExecFunctionScan_features, pstate);
+  TS_FEATURES_MARKER(nodeFunctionscan_ExecFunctionScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeGather.c
+++ b/src/backend/executor/nodeGather.c
@@ -249,7 +249,7 @@ ExecGather(PlanState *pstate)
   result = _ExecGather(pstate);
 
   TS_MARKER(nodeGather_ExecGather_end);
-  TS_MARKER(nodeGather_ExecGather_features);
+  TS_FEATURES_MARKER(nodeGather_ExecGather_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeGather.c
+++ b/src/backend/executor/nodeGather.c
@@ -252,7 +252,7 @@ ExecGather(PlanState *pstate)
   result = _ExecGather(pstate);
 
   TS_MARKER(nodeGather_ExecGather_end);
-  TS_FEATURES_MARKER(nodeGather_ExecGather_features, pstate);
+  TS_FEATURES_MARKER(nodeGather_ExecGather_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeGather.c
+++ b/src/backend/executor/nodeGather.c
@@ -243,7 +243,10 @@ _ExecGather(PlanState *pstate)
 static TupleTableSlot *
 ExecGather(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeGather_ExecGather_begin);
 
   result = _ExecGather(pstate);

--- a/src/backend/executor/nodeGather.c
+++ b/src/backend/executor/nodeGather.c
@@ -252,7 +252,7 @@ ExecGather(PlanState *pstate)
   result = _ExecGather(pstate);
 
   TS_MARKER(nodeGather_ExecGather_end);
-  TS_FEATURES_MARKER(nodeGather_ExecGather_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeGather_ExecGather_features, castNode(GatherState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeGatherMerge.c
+++ b/src/backend/executor/nodeGatherMerge.c
@@ -292,7 +292,7 @@ ExecGatherMerge(PlanState *pstate)
   result = _ExecGatherMerge(pstate);
 
   TS_MARKER(nodeGatherMerge_ExecGatherMerge_end);
-  TS_FEATURES_MARKER(nodeGatherMerge_ExecGatherMerge_features, pstate);
+  TS_FEATURES_MARKER(nodeGatherMerge_ExecGatherMerge_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeGatherMerge.c
+++ b/src/backend/executor/nodeGatherMerge.c
@@ -283,7 +283,10 @@ _ExecGatherMerge(PlanState *pstate)
 static TupleTableSlot *
 ExecGatherMerge(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeGatherMerge_ExecGatherMerge_begin);
 
   result = _ExecGatherMerge(pstate);

--- a/src/backend/executor/nodeGatherMerge.c
+++ b/src/backend/executor/nodeGatherMerge.c
@@ -292,7 +292,7 @@ ExecGatherMerge(PlanState *pstate)
   result = _ExecGatherMerge(pstate);
 
   TS_MARKER(nodeGatherMerge_ExecGatherMerge_end);
-  TS_FEATURES_MARKER(nodeGatherMerge_ExecGatherMerge_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeGatherMerge_ExecGatherMerge_features, castNode(GatherMergeState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeGatherMerge.c
+++ b/src/backend/executor/nodeGatherMerge.c
@@ -289,7 +289,7 @@ ExecGatherMerge(PlanState *pstate)
   result = _ExecGatherMerge(pstate);
 
   TS_MARKER(nodeGatherMerge_ExecGatherMerge_end);
-  TS_MARKER(nodeGatherMerge_ExecGatherMerge_features);
+  TS_FEATURES_MARKER(nodeGatherMerge_ExecGatherMerge_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -164,7 +164,7 @@ ExecGroup(PlanState *pstate)
   result = _ExecGroup(pstate);
 
   TS_MARKER(nodeGroup_ExecGroup_end);
-  TS_FEATURES_MARKER(nodeGroup_ExecGroup_features, pstate);
+  TS_FEATURES_MARKER(nodeGroup_ExecGroup_features, pstate, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -161,7 +161,7 @@ ExecGroup(PlanState *pstate)
   result = _ExecGroup(pstate);
 
   TS_MARKER(nodeGroup_ExecGroup_end);
-  TS_MARKER(nodeGroup_ExecGroup_features);
+  TS_FEATURES_MARKER(nodeGroup_ExecGroup_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -164,7 +164,7 @@ ExecGroup(PlanState *pstate)
   result = _ExecGroup(pstate);
 
   TS_MARKER(nodeGroup_ExecGroup_end);
-  TS_FEATURES_MARKER(nodeGroup_ExecGroup_features, pstate, pstate, pstate);
+  TS_FEATURES_MARKER(nodeGroup_ExecGroup_features, castNode(GroupState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -155,7 +155,10 @@ _ExecGroup(PlanState *pstate)
 static TupleTableSlot *
 ExecGroup(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeGroup_ExecGroup_begin);
 
   result = _ExecGroup(pstate);

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -578,7 +578,10 @@ _ExecHashJoinImpl(PlanState *pstate, bool parallel)
 
 static pg_attribute_always_inline TupleTableSlot *
 ExecHashJoinImpl(PlanState *pstate, bool parallel) {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeHashjoin_ExecHashJoinImpl_begin);
 
   result = _ExecHashJoinImpl(pstate, parallel);

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -584,7 +584,7 @@ ExecHashJoinImpl(PlanState *pstate, bool parallel) {
   result = _ExecHashJoinImpl(pstate, parallel);
 
   TS_MARKER(nodeHashjoin_ExecHashJoinImpl_end);
-  TS_MARKER(nodeHashjoin_ExecHashJoinImpl_features);
+  TS_FEATURES_MARKER(nodeHashjoin_ExecHashJoinImpl_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -587,7 +587,7 @@ ExecHashJoinImpl(PlanState *pstate, bool parallel) {
   result = _ExecHashJoinImpl(pstate, parallel);
 
   TS_MARKER(nodeHashjoin_ExecHashJoinImpl_end);
-  TS_FEATURES_MARKER(nodeHashjoin_ExecHashJoinImpl_features, pstate);
+  TS_FEATURES_MARKER(nodeHashjoin_ExecHashJoinImpl_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -587,7 +587,7 @@ ExecHashJoinImpl(PlanState *pstate, bool parallel) {
   result = _ExecHashJoinImpl(pstate, parallel);
 
   TS_MARKER(nodeHashjoin_ExecHashJoinImpl_end);
-  TS_FEATURES_MARKER(nodeHashjoin_ExecHashJoinImpl_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeHashjoin_ExecHashJoinImpl_features, castNode(HashJoinState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeIncrementalSort.c
+++ b/src/backend/executor/nodeIncrementalSort.c
@@ -968,7 +968,10 @@ _ExecIncrementalSort(PlanState *pstate)
 static TupleTableSlot *
 ExecIncrementalSort(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeIncrementalSort_ExecIncrementalSort_begin);
 
   result = _ExecIncrementalSort(pstate);

--- a/src/backend/executor/nodeIncrementalSort.c
+++ b/src/backend/executor/nodeIncrementalSort.c
@@ -977,7 +977,7 @@ ExecIncrementalSort(PlanState *pstate)
   result = _ExecIncrementalSort(pstate);
 
   TS_MARKER(nodeIncrementalSort_ExecIncrementalSort_end);
-  TS_FEATURES_MARKER(nodeIncrementalSort_ExecIncrementalSort_features, pstate);
+  TS_FEATURES_MARKER(nodeIncrementalSort_ExecIncrementalSort_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeIncrementalSort.c
+++ b/src/backend/executor/nodeIncrementalSort.c
@@ -977,7 +977,7 @@ ExecIncrementalSort(PlanState *pstate)
   result = _ExecIncrementalSort(pstate);
 
   TS_MARKER(nodeIncrementalSort_ExecIncrementalSort_end);
-  TS_FEATURES_MARKER(nodeIncrementalSort_ExecIncrementalSort_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeIncrementalSort_ExecIncrementalSort_features, castNode(IncrementalSortState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeIncrementalSort.c
+++ b/src/backend/executor/nodeIncrementalSort.c
@@ -974,7 +974,7 @@ ExecIncrementalSort(PlanState *pstate)
   result = _ExecIncrementalSort(pstate);
 
   TS_MARKER(nodeIncrementalSort_ExecIncrementalSort_end);
-  TS_MARKER(nodeIncrementalSort_ExecIncrementalSort_features);
+  TS_FEATURES_MARKER(nodeIncrementalSort_ExecIncrementalSort_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -323,7 +323,10 @@ _ExecIndexOnlyScan(PlanState *pstate)
 static TupleTableSlot *
 ExecIndexOnlyScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_begin);
 
   result = _ExecIndexOnlyScan(pstate);

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -332,7 +332,7 @@ ExecIndexOnlyScan(PlanState *pstate)
   result = _ExecIndexOnlyScan(pstate);
 
   TS_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_end);
-  TS_FEATURES_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_features, castNode(IndexOnlyScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -329,7 +329,7 @@ ExecIndexOnlyScan(PlanState *pstate)
   result = _ExecIndexOnlyScan(pstate);
 
   TS_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_end);
-  TS_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_features);
+  TS_FEATURES_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -332,7 +332,7 @@ ExecIndexOnlyScan(PlanState *pstate)
   result = _ExecIndexOnlyScan(pstate);
 
   TS_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_end);
-  TS_FEATURES_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_features, pstate);
+  TS_FEATURES_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -549,7 +549,7 @@ ExecIndexScan(PlanState *pstate)
   result = _ExecIndexScan(pstate);
 
   TS_MARKER(nodeIndexscan_ExecIndexScan_end);
-  TS_MARKER(nodeIndexscan_ExecIndexScan_features);
+  TS_FEATURES_MARKER(nodeIndexscan_ExecIndexScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -552,7 +552,7 @@ ExecIndexScan(PlanState *pstate)
   result = _ExecIndexScan(pstate);
 
   TS_MARKER(nodeIndexscan_ExecIndexScan_end);
-  TS_FEATURES_MARKER(nodeIndexscan_ExecIndexScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeIndexscan_ExecIndexScan_features, castNode(IndexScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -543,7 +543,10 @@ _ExecIndexScan(PlanState *pstate)
 static TupleTableSlot *
 ExecIndexScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeIndexscan_ExecIndexScan_begin);
 
   result = _ExecIndexScan(pstate);

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -552,7 +552,7 @@ ExecIndexScan(PlanState *pstate)
   result = _ExecIndexScan(pstate);
 
   TS_MARKER(nodeIndexscan_ExecIndexScan_end);
-  TS_FEATURES_MARKER(nodeIndexscan_ExecIndexScan_features, pstate);
+  TS_FEATURES_MARKER(nodeIndexscan_ExecIndexScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -354,7 +354,7 @@ ExecLimit(PlanState *pstate) {
   result = _ExecLimit(pstate);
 
   TS_MARKER(nodeLimit_ExecLimit_end);
-  TS_MARKER(nodeLimit_ExecLimit_features);
+  TS_FEATURES_MARKER(nodeLimit_ExecLimit_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -357,7 +357,7 @@ ExecLimit(PlanState *pstate) {
   result = _ExecLimit(pstate);
 
   TS_MARKER(nodeLimit_ExecLimit_end);
-  TS_FEATURES_MARKER(nodeLimit_ExecLimit_features, pstate);
+  TS_FEATURES_MARKER(nodeLimit_ExecLimit_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -348,7 +348,10 @@ _ExecLimit(PlanState *pstate)
 
 static TupleTableSlot *			/* return: a tuple or NULL */
 ExecLimit(PlanState *pstate) {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeLimit_ExecLimit_begin);
 
   result = _ExecLimit(pstate);

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -357,7 +357,7 @@ ExecLimit(PlanState *pstate) {
   result = _ExecLimit(pstate);
 
   TS_MARKER(nodeLimit_ExecLimit_end);
-  TS_FEATURES_MARKER(nodeLimit_ExecLimit_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeLimit_ExecLimit_features, castNode(LimitState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -291,7 +291,7 @@ ExecLockRows(PlanState *pstate)
   result = _ExecLockRows(pstate);
 
   TS_MARKER(nodeLockRows_ExecLockRows_end);
-  TS_MARKER(nodeLockRows_ExecLockRows_features);
+  TS_FEATURES_MARKER(nodeLockRows_ExecLockRows_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -294,7 +294,7 @@ ExecLockRows(PlanState *pstate)
   result = _ExecLockRows(pstate);
 
   TS_MARKER(nodeLockRows_ExecLockRows_end);
-  TS_FEATURES_MARKER(nodeLockRows_ExecLockRows_features, pstate);
+  TS_FEATURES_MARKER(nodeLockRows_ExecLockRows_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -294,7 +294,7 @@ ExecLockRows(PlanState *pstate)
   result = _ExecLockRows(pstate);
 
   TS_MARKER(nodeLockRows_ExecLockRows_end);
-  TS_FEATURES_MARKER(nodeLockRows_ExecLockRows_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeLockRows_ExecLockRows_features, castNode(LockRowsState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -285,7 +285,10 @@ lnext:
 static TupleTableSlot *
 ExecLockRows(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeLockRows_ExecLockRows_begin);
 
   result = _ExecLockRows(pstate);

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -169,7 +169,7 @@ ExecMaterial(PlanState *pstate)
   result = _ExecMaterial(pstate);
 
   TS_MARKER(nodeMaterial_ExecMaterial_end);
-  TS_FEATURES_MARKER(nodeMaterial_ExecMaterial_features, pstate);
+  TS_FEATURES_MARKER(nodeMaterial_ExecMaterial_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -160,7 +160,10 @@ _ExecMaterial(PlanState *pstate)
 static TupleTableSlot *
 ExecMaterial(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeMaterial_ExecMaterial_begin);
 
   result = _ExecMaterial(pstate);

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -166,7 +166,7 @@ ExecMaterial(PlanState *pstate)
   result = _ExecMaterial(pstate);
 
   TS_MARKER(nodeMaterial_ExecMaterial_end);
-  TS_MARKER(nodeMaterial_ExecMaterial_features);
+  TS_FEATURES_MARKER(nodeMaterial_ExecMaterial_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -169,7 +169,7 @@ ExecMaterial(PlanState *pstate)
   result = _ExecMaterial(pstate);
 
   TS_MARKER(nodeMaterial_ExecMaterial_end);
-  TS_FEATURES_MARKER(nodeMaterial_ExecMaterial_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeMaterial_ExecMaterial_features, castNode(MaterialState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -291,7 +291,7 @@ ExecMergeAppend(PlanState *pstate)
   result = _ExecMergeAppend(pstate);
 
   TS_MARKER(nodeMergeAppend_ExecMergeAppend_end);
-  TS_FEATURES_MARKER(nodeMergeAppend_ExecMergeAppend_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeMergeAppend_ExecMergeAppend_features, castNode(MergeAppendState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -288,7 +288,7 @@ ExecMergeAppend(PlanState *pstate)
   result = _ExecMergeAppend(pstate);
 
   TS_MARKER(nodeMergeAppend_ExecMergeAppend_end);
-  TS_MARKER(nodeMergeAppend_ExecMergeAppend_features);
+  TS_FEATURES_MARKER(nodeMergeAppend_ExecMergeAppend_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -282,7 +282,10 @@ _ExecMergeAppend(PlanState *pstate)
 static TupleTableSlot *
 ExecMergeAppend(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeMergeAppend_ExecMergeAppend_begin);
 
   result = _ExecMergeAppend(pstate);

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -291,7 +291,7 @@ ExecMergeAppend(PlanState *pstate)
   result = _ExecMergeAppend(pstate);
 
   TS_MARKER(nodeMergeAppend_ExecMergeAppend_end);
-  TS_FEATURES_MARKER(nodeMergeAppend_ExecMergeAppend_features, pstate);
+  TS_FEATURES_MARKER(nodeMergeAppend_ExecMergeAppend_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1441,7 +1441,7 @@ ExecMergeJoin(PlanState *pstate)
   result = _ExecMergeJoin(pstate);
 
   TS_MARKER(nodeMergejoin_ExecMergeJoin_end);
-  TS_FEATURES_MARKER(nodeMergejoin_ExecMergeJoin_features, pstate);
+  TS_FEATURES_MARKER(nodeMergejoin_ExecMergeJoin_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1432,7 +1432,10 @@ _ExecMergeJoin(PlanState *pstate)
 static TupleTableSlot *
 ExecMergeJoin(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeMergejoin_ExecMergeJoin_begin);
 
   result = _ExecMergeJoin(pstate);

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1441,7 +1441,7 @@ ExecMergeJoin(PlanState *pstate)
   result = _ExecMergeJoin(pstate);
 
   TS_MARKER(nodeMergejoin_ExecMergeJoin_end);
-  TS_FEATURES_MARKER(nodeMergejoin_ExecMergeJoin_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeMergejoin_ExecMergeJoin_features, castNode(MergeJoinState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1438,7 +1438,7 @@ ExecMergeJoin(PlanState *pstate)
   result = _ExecMergeJoin(pstate);
 
   TS_MARKER(nodeMergejoin_ExecMergeJoin_end);
-  TS_MARKER(nodeMergejoin_ExecMergeJoin_features);
+  TS_FEATURES_MARKER(nodeMergejoin_ExecMergeJoin_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2658,7 +2658,7 @@ ExecModifyTable(PlanState *pstate)
     result = _ExecModifyTable(pstate);
 
     TS_MARKER(nodeModifyTable_ExecModifyTable_end);
-    TS_FEATURES_MARKER(nodeModifyTable_ExecModifyTable_features, pstate, pstate);
+    TS_FEATURES_MARKER(nodeModifyTable_ExecModifyTable_features, castNode(ModifyTableState, pstate), pstate);
 
     return result;
 }

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2655,7 +2655,7 @@ ExecModifyTable(PlanState *pstate)
     result = _ExecModifyTable(pstate);
 
     TS_MARKER(nodeModifyTable_ExecModifyTable_end);
-    TS_MARKER(nodeModifyTable_ExecModifyTable_features);
+    TS_FEATURES_MARKER(nodeModifyTable_ExecModifyTable_features, pstate);
 
     return result;
 }

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2649,7 +2649,10 @@ _ExecModifyTable(PlanState *pstate)
 static TupleTableSlot *
 ExecModifyTable(PlanState *pstate)
 {
-    TupleTableSlot *result = NULL;
+    TupleTableSlot *result;
+    TS_MARKER_SETUP();
+
+    result = NULL;
     TS_MARKER(nodeModifyTable_ExecModifyTable_begin);
 
     result = _ExecModifyTable(pstate);

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2658,7 +2658,7 @@ ExecModifyTable(PlanState *pstate)
     result = _ExecModifyTable(pstate);
 
     TS_MARKER(nodeModifyTable_ExecModifyTable_end);
-    TS_FEATURES_MARKER(nodeModifyTable_ExecModifyTable_features, pstate);
+    TS_FEATURES_MARKER(nodeModifyTable_ExecModifyTable_features, pstate, pstate);
 
     return result;
 }

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -87,7 +87,7 @@ ExecNamedTuplestoreScan(PlanState *pstate)
   result = _ExecNamedTuplestoreScan(pstate);
 
   TS_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_end);
-  TS_FEATURES_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_features, pstate);
+  TS_FEATURES_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -84,7 +84,7 @@ ExecNamedTuplestoreScan(PlanState *pstate)
   result = _ExecNamedTuplestoreScan(pstate);
 
   TS_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_end);
-  TS_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_features);
+  TS_FEATURES_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -78,7 +78,10 @@ _ExecNamedTuplestoreScan(PlanState *pstate)
 static TupleTableSlot *
 ExecNamedTuplestoreScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_begin);
 
   result = _ExecNamedTuplestoreScan(pstate);

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -87,7 +87,7 @@ ExecNamedTuplestoreScan(PlanState *pstate)
   result = _ExecNamedTuplestoreScan(pstate);
 
   TS_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_end);
-  TS_FEATURES_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_features, castNode(NamedTuplestoreScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -265,7 +265,7 @@ ExecNestLoop(PlanState *pstate)
   result = _ExecNestLoop(pstate);
 
   TS_MARKER(nodeNestloop_ExecNestLoop_end);
-  TS_MARKER(nodeNestloop_ExecNestLoop_features);
+  TS_FEATURES_MARKER(nodeNestloop_ExecNestLoop_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -259,7 +259,10 @@ _ExecNestLoop(PlanState *pstate)
 static TupleTableSlot *
 ExecNestLoop(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeNestloop_ExecNestLoop_begin);
 
   result = _ExecNestLoop(pstate);

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -268,7 +268,7 @@ ExecNestLoop(PlanState *pstate)
   result = _ExecNestLoop(pstate);
 
   TS_MARKER(nodeNestloop_ExecNestLoop_end);
-  TS_FEATURES_MARKER(nodeNestloop_ExecNestLoop_features, pstate);
+  TS_FEATURES_MARKER(nodeNestloop_ExecNestLoop_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -268,7 +268,7 @@ ExecNestLoop(PlanState *pstate)
   result = _ExecNestLoop(pstate);
 
   TS_MARKER(nodeNestloop_ExecNestLoop_end);
-  TS_FEATURES_MARKER(nodeNestloop_ExecNestLoop_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeNestloop_ExecNestLoop_features, castNode(NestLoopState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeProjectSet.c
+++ b/src/backend/executor/nodeProjectSet.c
@@ -129,7 +129,7 @@ ExecProjectSet(PlanState *pstate)
   result = _ExecProjectSet(pstate);
 
   TS_MARKER(nodeProjectSet_ExecProjectSet_end);
-  TS_FEATURES_MARKER(nodeProjectSet_ExecProjectSet_features, pstate);
+  TS_FEATURES_MARKER(nodeProjectSet_ExecProjectSet_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeProjectSet.c
+++ b/src/backend/executor/nodeProjectSet.c
@@ -120,7 +120,10 @@ _ExecProjectSet(PlanState *pstate)
 static TupleTableSlot *
 ExecProjectSet(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeProjectSet_ExecProjectSet_begin);
 
   result = _ExecProjectSet(pstate);

--- a/src/backend/executor/nodeProjectSet.c
+++ b/src/backend/executor/nodeProjectSet.c
@@ -126,7 +126,7 @@ ExecProjectSet(PlanState *pstate)
   result = _ExecProjectSet(pstate);
 
   TS_MARKER(nodeProjectSet_ExecProjectSet_end);
-  TS_MARKER(nodeProjectSet_ExecProjectSet_features);
+  TS_FEATURES_MARKER(nodeProjectSet_ExecProjectSet_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeProjectSet.c
+++ b/src/backend/executor/nodeProjectSet.c
@@ -129,7 +129,7 @@ ExecProjectSet(PlanState *pstate)
   result = _ExecProjectSet(pstate);
 
   TS_MARKER(nodeProjectSet_ExecProjectSet_end);
-  TS_FEATURES_MARKER(nodeProjectSet_ExecProjectSet_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeProjectSet_ExecProjectSet_features, castNode(ProjectSetState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -169,7 +169,7 @@ ExecRecursiveUnion(PlanState *pstate)
   result = _ExecRecursiveUnion(pstate);
 
   TS_MARKER(nodeRecursiveunion_ExecRecursiveUnion_end);
-  TS_MARKER(nodeRecursiveunion_ExecRecursiveUnion_features);
+  TS_FEATURES_MARKER(nodeRecursiveunion_ExecRecursiveUnion_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -172,7 +172,7 @@ ExecRecursiveUnion(PlanState *pstate)
   result = _ExecRecursiveUnion(pstate);
 
   TS_MARKER(nodeRecursiveunion_ExecRecursiveUnion_end);
-  TS_FEATURES_MARKER(nodeRecursiveunion_ExecRecursiveUnion_features, pstate);
+  TS_FEATURES_MARKER(nodeRecursiveunion_ExecRecursiveUnion_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -163,7 +163,10 @@ _ExecRecursiveUnion(PlanState *pstate)
 static TupleTableSlot *
 ExecRecursiveUnion(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeRecursiveunion_ExecRecursiveUnion_begin);
 
   result = _ExecRecursiveUnion(pstate);

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -172,7 +172,7 @@ ExecRecursiveUnion(PlanState *pstate)
   result = _ExecRecursiveUnion(pstate);
 
   TS_MARKER(nodeRecursiveunion_ExecRecursiveUnion_end);
-  TS_FEATURES_MARKER(nodeRecursiveunion_ExecRecursiveUnion_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeRecursiveunion_ExecRecursiveUnion_features, castNode(RecursiveUnionState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -143,7 +143,10 @@ _ExecResult(PlanState *pstate)
 static TupleTableSlot *
 ExecResult(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeResult_ExecResult_begin);
 
   result = _ExecResult(pstate);

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -152,7 +152,7 @@ ExecResult(PlanState *pstate)
   result = _ExecResult(pstate);
 
   TS_MARKER(nodeResult_ExecResult_end);
-  TS_FEATURES_MARKER(nodeResult_ExecResult_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeResult_ExecResult_features, castNode(ResultState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -149,7 +149,7 @@ ExecResult(PlanState *pstate)
   result = _ExecResult(pstate);
 
   TS_MARKER(nodeResult_ExecResult_end);
-  TS_MARKER(nodeResult_ExecResult_features);
+  TS_FEATURES_MARKER(nodeResult_ExecResult_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -152,7 +152,7 @@ ExecResult(PlanState *pstate)
   result = _ExecResult(pstate);
 
   TS_MARKER(nodeResult_ExecResult_end);
-  TS_FEATURES_MARKER(nodeResult_ExecResult_features, pstate);
+  TS_FEATURES_MARKER(nodeResult_ExecResult_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSamplescan.c
+++ b/src/backend/executor/nodeSamplescan.c
@@ -92,7 +92,10 @@ _ExecSampleScan(PlanState *pstate)
 static TupleTableSlot *
 ExecSampleScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeSamplescan_ExecSampleScan_begin);
 
   result = _ExecSampleScan(pstate);

--- a/src/backend/executor/nodeSamplescan.c
+++ b/src/backend/executor/nodeSamplescan.c
@@ -101,7 +101,7 @@ ExecSampleScan(PlanState *pstate)
   result = _ExecSampleScan(pstate);
 
   TS_MARKER(nodeSamplescan_ExecSampleScan_end);
-  TS_FEATURES_MARKER(nodeSamplescan_ExecSampleScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeSamplescan_ExecSampleScan_features, castNode(SampleScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSamplescan.c
+++ b/src/backend/executor/nodeSamplescan.c
@@ -101,7 +101,7 @@ ExecSampleScan(PlanState *pstate)
   result = _ExecSampleScan(pstate);
 
   TS_MARKER(nodeSamplescan_ExecSampleScan_end);
-  TS_FEATURES_MARKER(nodeSamplescan_ExecSampleScan_features, pstate);
+  TS_FEATURES_MARKER(nodeSamplescan_ExecSampleScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSamplescan.c
+++ b/src/backend/executor/nodeSamplescan.c
@@ -98,7 +98,7 @@ ExecSampleScan(PlanState *pstate)
   result = _ExecSampleScan(pstate);
 
   TS_MARKER(nodeSamplescan_ExecSampleScan_end);
-  TS_MARKER(nodeSamplescan_ExecSampleScan_features);
+  TS_FEATURES_MARKER(nodeSamplescan_ExecSampleScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -127,7 +127,7 @@ ExecSeqScan(PlanState *pstate)
   result = _ExecSeqScan(pstate);
 
   TS_MARKER(nodeSeqscan_ExecSeqScan_end);
-  TS_FEATURES_MARKER(nodeSeqscan_ExecSeqScan_features, pstate);
+  TS_FEATURES_MARKER(nodeSeqscan_ExecSeqScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -124,7 +124,7 @@ ExecSeqScan(PlanState *pstate)
   result = _ExecSeqScan(pstate);
 
   TS_MARKER(nodeSeqscan_ExecSeqScan_end);
-  TS_MARKER(nodeSeqscan_ExecSeqScan_features);
+  TS_FEATURES_MARKER(nodeSeqscan_ExecSeqScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -127,7 +127,7 @@ ExecSeqScan(PlanState *pstate)
   result = _ExecSeqScan(pstate);
 
   TS_MARKER(nodeSeqscan_ExecSeqScan_end);
-  TS_FEATURES_MARKER(nodeSeqscan_ExecSeqScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeSeqscan_ExecSeqScan_features, castNode(SeqScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -118,7 +118,10 @@ _ExecSeqScan(PlanState *pstate)
 static TupleTableSlot *
 ExecSeqScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeSeqscan_ExecSeqScan_begin);
 
   result = _ExecSeqScan(pstate);

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -233,7 +233,7 @@ ExecSetOp(PlanState *pstate)
   result = _ExecSetOp(pstate);
 
   TS_MARKER(nodeSetOp_ExecSetOp_end);
-  TS_FEATURES_MARKER(nodeSetOp_ExecSetOp_features, pstate);
+  TS_FEATURES_MARKER(nodeSetOp_ExecSetOp_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -233,7 +233,7 @@ ExecSetOp(PlanState *pstate)
   result = _ExecSetOp(pstate);
 
   TS_MARKER(nodeSetOp_ExecSetOp_end);
-  TS_FEATURES_MARKER(nodeSetOp_ExecSetOp_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeSetOp_ExecSetOp_features, castNode(SetOpState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -224,7 +224,10 @@ _ExecSetOp(PlanState *pstate)
 static TupleTableSlot *
 ExecSetOp(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeSetOp_ExecSetOp_begin);
 
   result = _ExecSetOp(pstate);

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -230,7 +230,7 @@ ExecSetOp(PlanState *pstate)
   result = _ExecSetOp(pstate);
 
   TS_MARKER(nodeSetOp_ExecSetOp_end);
-  TS_MARKER(nodeSetOp_ExecSetOp_features);
+  TS_FEATURES_MARKER(nodeSetOp_ExecSetOp_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -166,7 +166,7 @@ ExecSort(PlanState *pstate)
   result = _ExecSort(pstate);
 
   TS_MARKER(nodeSort_ExecSort_end);
-  TS_MARKER(nodeSort_ExecSort_features);
+  TS_FEATURES_MARKER(nodeSort_ExecSort_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -160,7 +160,10 @@ _ExecSort(PlanState *pstate)
 static TupleTableSlot *
 ExecSort(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeSort_ExecSort_begin);
 
   result = _ExecSort(pstate);

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -169,7 +169,7 @@ ExecSort(PlanState *pstate)
   result = _ExecSort(pstate);
 
   TS_MARKER(nodeSort_ExecSort_end);
-  TS_FEATURES_MARKER(nodeSort_ExecSort_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeSort_ExecSort_features, castNode(SortState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -169,7 +169,7 @@ ExecSort(PlanState *pstate)
   result = _ExecSort(pstate);
 
   TS_MARKER(nodeSort_ExecSort_end);
-  TS_FEATURES_MARKER(nodeSort_ExecSort_features, pstate);
+  TS_FEATURES_MARKER(nodeSort_ExecSort_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -108,7 +108,7 @@ ExecSubPlan(SubPlanState *node,
   result = _ExecSubPlan(node, econtext, isNull);
 
   TS_MARKER(nodeSubplan_ExecSubPlan_end);
-  TS_FEATURES_MARKER(nodeSubplan_ExecSubPlan_features, node, node->planstate);
+  TS_FEATURES_MARKER(nodeSubplan_ExecSubPlan_features, castNode(SubPlanState, node), node->planstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -101,6 +101,8 @@ ExecSubPlan(SubPlanState *node,
 			bool *isNull)
 {
   Datum result;
+  TS_MARKER_SETUP();
+
   TS_MARKER(nodeSubplan_ExecSubPlan_begin);
 
   result = _ExecSubPlan(node, econtext, isNull);

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -106,7 +106,7 @@ ExecSubPlan(SubPlanState *node,
   result = _ExecSubPlan(node, econtext, isNull);
 
   TS_MARKER(nodeSubplan_ExecSubPlan_end);
-  TS_MARKER(nodeSubplan_ExecSubPlan_features);
+  TS_FEATURES_MARKER(nodeSubplan_ExecSubPlan_features, node->planstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -108,7 +108,7 @@ ExecSubPlan(SubPlanState *node,
   result = _ExecSubPlan(node, econtext, isNull);
 
   TS_MARKER(nodeSubplan_ExecSubPlan_end);
-  TS_FEATURES_MARKER(nodeSubplan_ExecSubPlan_features, node->planstate);
+  TS_FEATURES_MARKER(nodeSubplan_ExecSubPlan_features, node, node->planstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -102,7 +102,7 @@ ExecSubqueryScan(PlanState *pstate)
   result = _ExecSubqueryScan(pstate);
 
   TS_MARKER(nodeSubqueryscan_ExecSubqueryScan_end);
-  TS_FEATURES_MARKER(nodeSubqueryscan_ExecSubqueryScan_features, pstate);
+  TS_FEATURES_MARKER(nodeSubqueryscan_ExecSubqueryScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -93,7 +93,10 @@ _ExecSubqueryScan(PlanState *pstate)
 static TupleTableSlot *
 ExecSubqueryScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeSubqueryscan_ExecSubqueryScan_begin);
 
   result = _ExecSubqueryScan(pstate);

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -102,7 +102,7 @@ ExecSubqueryScan(PlanState *pstate)
   result = _ExecSubqueryScan(pstate);
 
   TS_MARKER(nodeSubqueryscan_ExecSubqueryScan_end);
-  TS_FEATURES_MARKER(nodeSubqueryscan_ExecSubqueryScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeSubqueryscan_ExecSubqueryScan_features, castNode(SubqueryScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -99,7 +99,7 @@ ExecSubqueryScan(PlanState *pstate)
   result = _ExecSubqueryScan(pstate);
 
   TS_MARKER(nodeSubqueryscan_ExecSubqueryScan_end);
-  TS_MARKER(nodeSubqueryscan_ExecSubqueryScan_features);
+  TS_FEATURES_MARKER(nodeSubqueryscan_ExecSubqueryScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeTableFuncscan.c
+++ b/src/backend/executor/nodeTableFuncscan.c
@@ -115,7 +115,7 @@ ExecTableFuncScan(PlanState *pstate)
   result = _ExecTableFuncScan(pstate);
 
   TS_MARKER(nodeTableFuncscan_ExecTableFuncScan_end);
-  TS_FEATURES_MARKER(nodeTableFuncscan_ExecTableFuncScan_features, pstate);
+  TS_FEATURES_MARKER(nodeTableFuncscan_ExecTableFuncScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeTableFuncscan.c
+++ b/src/backend/executor/nodeTableFuncscan.c
@@ -106,7 +106,10 @@ _ExecTableFuncScan(PlanState *pstate)
 static TupleTableSlot *
 ExecTableFuncScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeTableFuncscan_ExecTableFuncScan_begin);
 
   result = _ExecTableFuncScan(pstate);

--- a/src/backend/executor/nodeTableFuncscan.c
+++ b/src/backend/executor/nodeTableFuncscan.c
@@ -112,7 +112,7 @@ ExecTableFuncScan(PlanState *pstate)
   result = _ExecTableFuncScan(pstate);
 
   TS_MARKER(nodeTableFuncscan_ExecTableFuncScan_end);
-  TS_MARKER(nodeTableFuncscan_ExecTableFuncScan_features);
+  TS_FEATURES_MARKER(nodeTableFuncscan_ExecTableFuncScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeTableFuncscan.c
+++ b/src/backend/executor/nodeTableFuncscan.c
@@ -115,7 +115,7 @@ ExecTableFuncScan(PlanState *pstate)
   result = _ExecTableFuncScan(pstate);
 
   TS_MARKER(nodeTableFuncscan_ExecTableFuncScan_end);
-  TS_FEATURES_MARKER(nodeTableFuncscan_ExecTableFuncScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeTableFuncscan_ExecTableFuncScan_features, castNode(TableFuncScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -441,7 +441,10 @@ _ExecTidScan(PlanState *pstate)
 static TupleTableSlot *
 ExecTidScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeTidscan_ExecTidScan_begin);
 
   result = _ExecTidScan(pstate);

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -450,7 +450,7 @@ ExecTidScan(PlanState *pstate)
   result = _ExecTidScan(pstate);
 
   TS_MARKER(nodeTidscan_ExecTidScan_end);
-  TS_FEATURES_MARKER(nodeTidscan_ExecTidScan_features, pstate);
+  TS_FEATURES_MARKER(nodeTidscan_ExecTidScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -447,7 +447,7 @@ ExecTidScan(PlanState *pstate)
   result = _ExecTidScan(pstate);
 
   TS_MARKER(nodeTidscan_ExecTidScan_end);
-  TS_MARKER(nodeTidscan_ExecTidScan_features);
+  TS_FEATURES_MARKER(nodeTidscan_ExecTidScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -450,7 +450,7 @@ ExecTidScan(PlanState *pstate)
   result = _ExecTidScan(pstate);
 
   TS_MARKER(nodeTidscan_ExecTidScan_end);
-  TS_FEATURES_MARKER(nodeTidscan_ExecTidScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeTidscan_ExecTidScan_features, castNode(TidScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -114,7 +114,7 @@ ExecUnique(PlanState *pstate)
   result = _ExecUnique(pstate);
 
   TS_MARKER(nodeUnique_ExecUnique_end);
-  TS_MARKER(nodeUnique_ExecUnique_features);
+  TS_FEATURES_MARKER(nodeUnique_ExecUnique_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -108,7 +108,10 @@ _ExecUnique(PlanState *pstate)
 static TupleTableSlot *
 ExecUnique(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeUnique_ExecUnique_begin);
 
   result = _ExecUnique(pstate);

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -117,7 +117,7 @@ ExecUnique(PlanState *pstate)
   result = _ExecUnique(pstate);
 
   TS_MARKER(nodeUnique_ExecUnique_end);
-  TS_FEATURES_MARKER(nodeUnique_ExecUnique_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeUnique_ExecUnique_features, castNode(UniqueState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -117,7 +117,7 @@ ExecUnique(PlanState *pstate)
   result = _ExecUnique(pstate);
 
   TS_MARKER(nodeUnique_ExecUnique_end);
-  TS_FEATURES_MARKER(nodeUnique_ExecUnique_features, pstate);
+  TS_FEATURES_MARKER(nodeUnique_ExecUnique_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -207,7 +207,10 @@ _ExecValuesScan(PlanState *pstate)
 static TupleTableSlot *
 ExecValuesScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeValuesscan_ExecValuesScan_begin);
 
   result = _ExecValuesScan(pstate);

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -213,7 +213,7 @@ ExecValuesScan(PlanState *pstate)
   result = _ExecValuesScan(pstate);
 
   TS_MARKER(nodeValuesscan_ExecValuesScan_end);
-  TS_MARKER(nodeValuesscan_ExecValuesScan_features);
+  TS_FEATURES_MARKER(nodeValuesscan_ExecValuesScan_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -216,7 +216,7 @@ ExecValuesScan(PlanState *pstate)
   result = _ExecValuesScan(pstate);
 
   TS_MARKER(nodeValuesscan_ExecValuesScan_end);
-  TS_FEATURES_MARKER(nodeValuesscan_ExecValuesScan_features, pstate);
+  TS_FEATURES_MARKER(nodeValuesscan_ExecValuesScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -216,7 +216,7 @@ ExecValuesScan(PlanState *pstate)
   result = _ExecValuesScan(pstate);
 
   TS_MARKER(nodeValuesscan_ExecValuesScan_end);
-  TS_FEATURES_MARKER(nodeValuesscan_ExecValuesScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeValuesscan_ExecValuesScan_features, castNode(ValuesScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -2242,7 +2242,10 @@ _ExecWindowAgg(PlanState *pstate)
 static TupleTableSlot *
 ExecWindowAgg(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeWindowAgg_ExecWindowAgg_begin);
 
   result = _ExecWindowAgg(pstate);

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -2251,7 +2251,7 @@ ExecWindowAgg(PlanState *pstate)
   result = _ExecWindowAgg(pstate);
 
   TS_MARKER(nodeWindowAgg_ExecWindowAgg_end);
-  TS_FEATURES_MARKER(nodeWindowAgg_ExecWindowAgg_features, pstate);
+  TS_FEATURES_MARKER(nodeWindowAgg_ExecWindowAgg_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -2248,7 +2248,7 @@ ExecWindowAgg(PlanState *pstate)
   result = _ExecWindowAgg(pstate);
 
   TS_MARKER(nodeWindowAgg_ExecWindowAgg_end);
-  TS_MARKER(nodeWindowAgg_ExecWindowAgg_features);
+  TS_FEATURES_MARKER(nodeWindowAgg_ExecWindowAgg_features, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -2251,7 +2251,7 @@ ExecWindowAgg(PlanState *pstate)
   result = _ExecWindowAgg(pstate);
 
   TS_MARKER(nodeWindowAgg_ExecWindowAgg_end);
-  TS_FEATURES_MARKER(nodeWindowAgg_ExecWindowAgg_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeWindowAgg_ExecWindowAgg_features, castNode(WindowAggState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -125,7 +125,10 @@ _ExecWorkTableScan(PlanState *pstate)
 static TupleTableSlot *
 ExecWorkTableScan(PlanState *pstate)
 {
-  TupleTableSlot *result = NULL;
+  TupleTableSlot *result;
+  TS_MARKER_SETUP();
+
+  result = NULL;
   TS_MARKER(nodeWorktablescan_ExecWorkTableScan_begin);
 
   result = _ExecWorkTableScan(pstate);

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -134,7 +134,7 @@ ExecWorkTableScan(PlanState *pstate)
   result = _ExecWorkTableScan(pstate);
 
   TS_MARKER(nodeWorktablescan_ExecWorkTableScan_end);
-  TS_FEATURES_MARKER(nodeWorktablescan_ExecWorkTableScan_features, pstate);
+  TS_FEATURES_MARKER(nodeWorktablescan_ExecWorkTableScan_features, pstate, pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -134,7 +134,7 @@ ExecWorkTableScan(PlanState *pstate)
   result = _ExecWorkTableScan(pstate);
 
   TS_MARKER(nodeWorktablescan_ExecWorkTableScan_end);
-  TS_FEATURES_MARKER(nodeWorktablescan_ExecWorkTableScan_features, pstate, pstate);
+  TS_FEATURES_MARKER(nodeWorktablescan_ExecWorkTableScan_features, castNode(WorkTableScanState, pstate), pstate);
 
   return result;
 }

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -131,7 +131,7 @@ ExecWorkTableScan(PlanState *pstate)
   result = _ExecWorkTableScan(pstate);
 
   TS_MARKER(nodeWorktablescan_ExecWorkTableScan_end);
-  TS_MARKER(nodeWorktablescan_ExecWorkTableScan_features);
+  TS_FEATURES_MARKER(nodeWorktablescan_ExecWorkTableScan_features, pstate);
 
   return result;
 }

--- a/src/include/tscout/marker.h
+++ b/src/include/tscout/marker.h
@@ -36,6 +36,7 @@
   TS_MARKER(                                                                                    \
     name,                                                                                       \
     query_id,                                                                                   \
-    cur_node,                                                                               \
+    cur_node,                                                                                   \
+    plan_state_ptr,                                                                             \
     ##__VA_ARGS__                                                                               \
   );

--- a/src/include/tscout/marker.h
+++ b/src/include/tscout/marker.h
@@ -32,6 +32,6 @@
 // Define common features.
 #define TS_FEATURES_MARKER(name, plan_state_ptr, ...)                                           \
   query_id = plan_state_ptr->state->es_plannedstmt->queryId;                                    \
-  estimated_num_rows = (double) plan_state_ptr->plan->plan_rows;                                \
+  estimated_num_rows = (uint64_t) plan_state_ptr->plan->plan_rows;                              \
   estimated_row_width_bytes = plan_state_ptr->plan->plan_width;                                 \
   TS_MARKER(name, query_id, estimated_num_rows, estimated_row_width_bytes, ##__VA_ARGS__);

--- a/src/include/tscout/marker.h
+++ b/src/include/tscout/marker.h
@@ -21,3 +21,13 @@
 
 // Test if previously-definied semaphore is in use
 #define TS_MARKER_IS_ENABLED(name) (FOLLY_SDT_SEMAPHORE(noisepage, name) > 0)
+
+// Define common features.
+#define TS_FEATURES_MARKER(name, plan_state_ptr, ...) \
+  uint64_t query_id;                                  \
+  double estimated_num_rows;                          \
+  int estimated_row_width_bytes;                      \
+  query_id = plan_state_ptr->state->es_plannedstmt->queryId; \
+  estimated_num_rows = plan_state_ptr->plan->plan_rows; \
+  estimated_row_width_bytes = plan_state_ptr->plan->plan_width; \
+  TS_MARKER(name, query_id, estimated_num_rows, estimated_row_width_bytes);

--- a/src/include/tscout/marker.h
+++ b/src/include/tscout/marker.h
@@ -37,6 +37,6 @@
     name,                                                                                       \
     query_id,                                                                                   \
     cur_node,                                                                                   \
-    plan_state_ptr->state,                                                                      \
+    plan_state_ptr->plan,                                                                       \
     ##__VA_ARGS__                                                                               \
   );

--- a/src/include/tscout/marker.h
+++ b/src/include/tscout/marker.h
@@ -26,12 +26,12 @@
 #define TS_MARKER_SETUP()               \
   /* Features. */                       \
   uint64_t query_id;                    \
-  double estimated_num_rows;            \
+  uint64_t estimated_num_rows;          \
   int estimated_row_width_bytes;
 
 // Define common features.
-#define TS_FEATURES_MARKER(name, plan_state_ptr, ...) \
-  query_id = plan_state_ptr->state->es_plannedstmt->queryId; \
-  estimated_num_rows = plan_state_ptr->plan->plan_rows; \
-  estimated_row_width_bytes = plan_state_ptr->plan->plan_width; \
+#define TS_FEATURES_MARKER(name, plan_state_ptr, ...)                                           \
+  query_id = plan_state_ptr->state->es_plannedstmt->queryId;                                    \
+  estimated_num_rows = (double) plan_state_ptr->plan->plan_rows;                                \
+  estimated_row_width_bytes = plan_state_ptr->plan->plan_width;                                 \
   TS_MARKER(name, query_id, estimated_num_rows, estimated_row_width_bytes, ##__VA_ARGS__);

--- a/src/include/tscout/marker.h
+++ b/src/include/tscout/marker.h
@@ -23,15 +23,19 @@
 #define TS_MARKER_IS_ENABLED(name) (FOLLY_SDT_SEMAPHORE(noisepage, name) > 0)
 
 // Define variables required by all of the markers. This avoids the C90 warnings.
-#define TS_MARKER_SETUP()               \
-  /* Features. */                       \
-  uint64_t query_id;                    \
-  uint64_t estimated_num_rows;          \
-  int estimated_row_width_bytes;
+#define TS_MARKER_SETUP()                                                                       \
+  /* Features. */                                                                               \
+  uint64_t query_id;                                                                            \
+  /* The current node. */                                                                       \
+  void *cur_node;
 
 // Define common features.
-#define TS_FEATURES_MARKER(name, plan_state_ptr, ...)                                           \
+#define TS_FEATURES_MARKER(name, current_node, plan_state_ptr, ...)                             \
   query_id = plan_state_ptr->state->es_plannedstmt->queryId;                                    \
-  estimated_num_rows = (uint64_t) plan_state_ptr->plan->plan_rows;                              \
-  estimated_row_width_bytes = plan_state_ptr->plan->plan_width;                                 \
-  TS_MARKER(name, query_id, estimated_num_rows, estimated_row_width_bytes, ##__VA_ARGS__);
+  cur_node = (void *) current_node;                                                             \
+  TS_MARKER(                                                                                    \
+    name,                                                                                       \
+    query_id,                                                                                   \
+    cur_node,                                                                               \
+    ##__VA_ARGS__                                                                               \
+  );

--- a/src/include/tscout/marker.h
+++ b/src/include/tscout/marker.h
@@ -36,7 +36,7 @@
   TS_MARKER(                                                                                    \
     name,                                                                                       \
     query_id,                                                                                   \
-    cur_node,                                                                                   \
     plan_state_ptr->plan,                                                                       \
+    cur_node,                                                                                   \
     ##__VA_ARGS__                                                                               \
   );

--- a/src/include/tscout/marker.h
+++ b/src/include/tscout/marker.h
@@ -22,12 +22,16 @@
 // Test if previously-definied semaphore is in use
 #define TS_MARKER_IS_ENABLED(name) (FOLLY_SDT_SEMAPHORE(noisepage, name) > 0)
 
+// Define variables required by all of the markers. This avoids the C90 warnings.
+#define TS_MARKER_SETUP()               \
+  /* Features. */                       \
+  uint64_t query_id;                    \
+  double estimated_num_rows;            \
+  int estimated_row_width_bytes;
+
 // Define common features.
 #define TS_FEATURES_MARKER(name, plan_state_ptr, ...) \
-  uint64_t query_id;                                  \
-  double estimated_num_rows;                          \
-  int estimated_row_width_bytes;                      \
   query_id = plan_state_ptr->state->es_plannedstmt->queryId; \
   estimated_num_rows = plan_state_ptr->plan->plan_rows; \
   estimated_row_width_bytes = plan_state_ptr->plan->plan_width; \
-  TS_MARKER(name, query_id, estimated_num_rows, estimated_row_width_bytes);
+  TS_MARKER(name, query_id, estimated_num_rows, estimated_row_width_bytes, ##__VA_ARGS__);

--- a/src/include/tscout/marker.h
+++ b/src/include/tscout/marker.h
@@ -37,6 +37,6 @@
     name,                                                                                       \
     query_id,                                                                                   \
     cur_node,                                                                                   \
-    plan_state_ptr,                                                                             \
+    plan_state_ptr->state,                                                                      \
     ##__VA_ARGS__                                                                               \
   );

--- a/src/include/tscout/marker.h
+++ b/src/include/tscout/marker.h
@@ -36,7 +36,7 @@
   TS_MARKER(                                                                                    \
     name,                                                                                       \
     query_id,                                                                                   \
-    plan_state_ptr->plan,                                                                       \
     cur_node,                                                                                   \
+    plan_state_ptr->plan,                                                                       \
     ##__VA_ARGS__                                                                               \
   );


### PR DESCRIPTION
This PR makes TScout emit the following tuple for every features marker:

- Query ID (u64)
- Current state object (void *)
- Plan state object (void *)

To silence C90 warnings, it also separates variable declaration from variable initialization.

---

**C things**

For some baffling reason, I seem to remember needing to `castNode(...)`, e.g., `(void *) (IndexScanState *) foo` instead of `(void *) foo` for `PlanState *foo` in the expansion of `TS_FEATURES_MARKER`. I can see why this works, but I don't see why this is necessary. C17 spec:

> 6.3.2.3.7 A pointer to an object type may be converted to a pointer to a different object type. If the resulting pointer is not correctly aligned for the referenced type, the behavior is undefined. Otherwise, when converted back again, the result shall compare equal to the original pointer.
> 6.7.2.1.15 A pointer to a structure object, suitably converted, points to its initial member (or if that member is a bit-field, then to the unit in which it resides), and vice versa.