### PR TITLE
Fix TScout/Collector formatting of float and double output.

### DIFF
--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -67,9 +67,9 @@ class BPFVariable:
         """
         val = str(getattr(output_event, self.name))
         if self.c_type == clang.cindex.TypeKind.FLOAT:
-            return struct.unpack('f', struct.pack('l', int(val)))[0]
+            return str(struct.unpack('f', struct.pack('l', int(val)))[0])
         elif self.c_type == clang.cindex.TypeKind.DOUBLE:
-            return struct.unpack('d', struct.pack('q', int(val)))[0]
+            return str(struct.unpack('d', struct.pack('q', int(val)))[0])
         else:
             return val
 

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -5,12 +5,12 @@ Convert C types to BPF types.
 Define the Operating Units (OUs) and metrics to be collected.
 """
 
+import struct
 from dataclasses import dataclass
 from enum import Enum, unique
 from typing import List, Mapping, Tuple
 
 import clang.cindex
-
 import clang_parser
 
 
@@ -32,6 +32,45 @@ class BPFVariable:
     """A BPF variable has a type and a name."""
     bpf_type: BPFType
     name: str
+    c_type: clang.cindex.TypeKind
+
+    def should_output(self):
+        """
+        Return whether this variable should be included in Processor output.
+
+        Returns
+        -------
+        True if the variable should be output. False otherwise.
+        Some variables should not be output, e.g., pointers,
+        as the values do not make sense from a ML perspective.
+        """
+        suppressed = [
+            clang.cindex.TypeKind.POINTER,
+            clang.cindex.TypeKind.FUNCTIONPROTO,
+        ]
+        return self.c_type not in suppressed
+
+    def serialize(self, output_event):
+        """
+        Serialize this variable given the output event containing its value.
+
+        Parameters
+        ----------
+        output_event
+            The perf output event that contains the output value for this var.
+
+        Returns
+        -------
+        val : str
+            The serialized value of this variable.
+        """
+        val = str(getattr(output_event, self.name))
+        if self.c_type == clang.cindex.TypeKind.FLOAT:
+            return struct.unpack('f', struct.pack('l', val))
+        elif self.c_type == clang.cindex.TypeKind.DOUBLE:
+            return struct.unpack('d', struct.pack('q', val))
+        else:
+            return val
 
 
 @dataclass
@@ -52,7 +91,7 @@ class Feature:
     bpf_tuple: Tuple[BPFVariable] = None
 
 
-QUERY_ID = (BPFVariable(BPFType.u64, "query_id"),)
+QUERY_ID = (BPFVariable(BPFType.u64, "query_id", clang.cindex.TypeKind.ULONG),)
 
 """
 An OU is specified via (operator, postgres_function, feature_types).
@@ -334,6 +373,11 @@ class OperatingUnit:
         return self.name() + '_features'
 
     def features_struct(self) -> str:
+        """
+        Returns
+        -------
+        C struct definition of all the features in the OU.
+        """
         struct_def = ';\n'.join(
             '{} {}'.format(column.bpf_type, column.name)
             for feature in self.features_list
@@ -342,17 +386,39 @@ class OperatingUnit:
         return struct_def + ';'
 
     def features_columns(self) -> str:
+        """
+        Returns
+        -------
+        Comma-separated string of all the features this OU outputs.
+        This may not be all the features that comprise the OU.
+        """
         return ','.join(
             column.name
             for feature in self.features_list
             for column in feature.bpf_tuple
+            if column.should_output()
         )
 
     def serialize_features(self, output_event) -> str:
+        """
+        Serialize the feature values for this OU.
+
+        Parameters
+        ----------
+        output_event
+            The output event that contains feature values for all the
+            features that this OU contains.
+
+        Returns
+        -------
+        Comma-separated string of all the features this OU outputs.
+        This may not be all the features that comprise the OU.
+        """
         return ','.join(
-            str(getattr(output_event, column.name))
+            column.serialize(output_event)
             for feature in self.features_list
             for column in feature.bpf_tuple
+            if column.should_output()
         )
 
     def helper_structs(self) -> Mapping[str, str]:
@@ -411,8 +477,9 @@ class Model:
                 # Otherwise, convert the list of fields to BPF types.
                 bpf_fields = tuple([
                     BPFVariable(
-                        Model.CLANG_TO_BPF[field.canonical_type_kind],
-                        field.name
+                        bpf_type=Model.CLANG_TO_BPF[field.canonical_type_kind],
+                        name=field.name,
+                        c_type=field.canonical_type_kind,
                     )
                     for i, field in enumerate(nodes.field_map[feature.name])
                 ])

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -67,9 +67,9 @@ class BPFVariable:
         """
         val = str(getattr(output_event, self.name))
         if self.c_type == clang.cindex.TypeKind.FLOAT:
-            return struct.unpack('f', struct.pack('l', val))
+            return struct.unpack('f', struct.pack('l', int(val)))
         elif self.c_type == clang.cindex.TypeKind.DOUBLE:
-            return struct.unpack('d', struct.pack('q', val))
+            return struct.unpack('d', struct.pack('q', int(val)))
         else:
             return val
 

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -67,9 +67,9 @@ class BPFVariable:
         """
         val = str(getattr(output_event, self.name))
         if self.c_type == clang.cindex.TypeKind.FLOAT:
-            return struct.unpack('f', struct.pack('l', int(val)))
+            return struct.unpack('f', struct.pack('l', int(val)))[0]
         elif self.c_type == clang.cindex.TypeKind.DOUBLE:
-            return struct.unpack('d', struct.pack('q', int(val)))
+            return struct.unpack('d', struct.pack('q', int(val)))[0]
         else:
             return val
 

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -11,6 +11,7 @@ from enum import Enum, unique
 from typing import List, Mapping, Tuple
 
 import clang.cindex
+
 import clang_parser
 
 
@@ -325,20 +326,48 @@ OU_DEFS = [
 
 # The metrics to be defined for every OU.
 OU_METRICS = (
-    BPFVariable(BPFType.u64, "start_time"),
-    BPFVariable(BPFType.u64, "end_time"),
-    BPFVariable(BPFType.u8, "cpu_id"),
-    BPFVariable(BPFType.u64, "cpu_cycles"),
-    BPFVariable(BPFType.u64, "instructions"),
-    BPFVariable(BPFType.u64, "cache_references"),
-    BPFVariable(BPFType.u64, "cache_misses"),
-    BPFVariable(BPFType.u64, "ref_cpu_cycles"),
-    BPFVariable(BPFType.u64, "network_bytes_read"),
-    BPFVariable(BPFType.u64, "network_bytes_written"),
-    BPFVariable(BPFType.u64, "disk_bytes_read"),
-    BPFVariable(BPFType.u64, "disk_bytes_written"),
-    BPFVariable(BPFType.u64, "memory_bytes"),
-    BPFVariable(BPFType.u64, "elapsed_us")
+    BPFVariable(bpf_type=BPFType.u64,
+                name="start_time",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="end_time",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u8,
+                name="cpu_id",
+                c_type=clang.cindex.TypeKind.UCHAR),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="cpu_cycles",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="instructions",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="cache_references",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="cache_misses",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="ref_cpu_cycles",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="network_bytes_read",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="network_bytes_written",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="disk_bytes_read",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="disk_bytes_written",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="memory_bytes",
+                c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(bpf_type=BPFType.u64,
+                name="elapsed_us",
+                c_type=clang.cindex.TypeKind.ULONG)
 )
 
 

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -1,12 +1,11 @@
 #!/usr/bin/python3
 import multiprocessing as mp
 import sys
-from typing import List, Tuple
-
-import setproctitle
-from bcc import BPF, USDT, PerfHWConfig, PerfType, utils
+from typing import List
 
 import model
+import setproctitle
+from bcc import BPF, USDT, PerfHWConfig, PerfType, utils
 
 # Set up the OUs and metrics to be collected.
 modeler = model.Model()

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -3,9 +3,10 @@ import multiprocessing as mp
 import sys
 from typing import List
 
-import model
 import setproctitle
 from bcc import BPF, USDT, PerfHWConfig, PerfType, utils
+
+import model
 
 # Set up the OUs and metrics to be collected.
 modeler = model.Model()


### PR DESCRIPTION
Currently, TScout outputs floats and doubles as their byte representation, e.g., `140310644383656`.

We can pack/unpack C structs in Python to output the true float/double value.
To do so, we now track the original C type in the `BPFVariable`.

Another advantage of this approach is that we can centralize "Should this feature be collected? How should this feature be formatted?" into the `BPFVariable` class.

Tested with SeqScan on dev10.