### PR TITLE
Refactor executors for TScout markers

### DIFF
--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -106,217 +106,217 @@ feature_types : List[Feature]
     If you modify this list, you must change the markers in PostgreSQL source.
 """
 OU_DEFS = [
-    ("nodeAgg", "ExecAgg",
+    ("ExecAgg",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("AggState"),
          Feature("Plan")
      ]),
-    ("nodeAppend", "ExecAppend",
+    ("ExecAppend",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("AppendState"),
          Feature("Plan")
      ]),
-    ("nodeCtescan", "ExecCteScan",
+    ("ExecCteScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("CteScanState"),
          Feature("Plan")
      ]),
-    ("nodeCustom", "ExecCustomScan",
+    ("ExecCustomScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("CustomScanState"),
          Feature("Plan")
      ]),
-    ("nodeForeignscan", "ExecForeignScan",
+    ("ExecForeignScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("ForeignScanState"),
          Feature("Plan")
      ]),
-    ("nodeFunctionscan", "ExecFunctionScan",
+    ("ExecFunctionScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("FunctionScanState"),
          Feature("Plan")
      ]),
-    ("nodeGather", "ExecGather",
+    ("ExecGather",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("GatherState"),
          Feature("Plan")
      ]),
-    ("nodeGatherMerge", "ExecGatherMerge",
+    ("ExecGatherMerge",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("GatherMergeState"),
          Feature("Plan")
      ]),
-    ("nodeGroup", "ExecGroup",
+    ("ExecGroup",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("GroupState"),
          Feature("Plan")
      ]),
-    ("nodeHashjoin", "ExecHashJoinImpl",
+    ("ExecHashJoinImpl",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("HashJoinState"),
          Feature("Plan")
      ]),
-    ("nodeIncrementalSort", "ExecIncrementalSort",
+    ("ExecIncrementalSort",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("IncrementalSortState"),
          Feature("Plan")
      ]),
-    ("nodeIndexonlyscan", "ExecIndexOnlyScan",
+    ("ExecIndexOnlyScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("IndexOnlyScanState"),
          Feature("Plan")
      ]),
-    ("nodeIndexscan", "ExecIndexScan",
+    ("ExecIndexScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("IndexScanState"),
          Feature("Plan")
      ]),
-    ("nodeLimit", "ExecLimit",
+    ("ExecLimit",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("LimitState"),
          Feature("Plan")
      ]),
-    ("nodeLockRows", "ExecLockRows",
+    ("ExecLockRows",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("LockRowsState"),
          Feature("Plan")
      ]),
-    ("nodeMaterial", "ExecMaterial",
+    ("ExecMaterial",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("MaterialState"),
          Feature("Plan")
      ]),
-    ("nodeMergeAppend", "ExecMergeAppend",
+    ("ExecMergeAppend",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("MergeAppendState"),
          Feature("Plan")
      ]),
-    ("nodeMergejoin", "ExecMergeJoin",
+    ("ExecMergeJoin",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("MergeJoinState"),
          Feature("Plan")
      ]),
-    ("nodeModifyTable", "ExecModifyTable",
+    ("ExecModifyTable",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("ModifyTableState"),
          Feature("Plan")
      ]),
-    ("nodeNamedtuplestorescan", "ExecNamedTuplestoreScan",
+    ("ExecNamedTuplestoreScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("NamedTuplestoreScanState"),
          Feature("Plan")
      ]),
-    ("nodeNestloop", "ExecNestLoop",
+    ("ExecNestLoop",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("NestLoopState"),
          Feature("Plan")
      ]),
-    ("nodeProjectSet", "ExecProjectSet",
+    ("ExecProjectSet",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("ProjectSetState"),
          Feature("Plan")
      ]),
-    ("nodeRecursiveunion", "ExecRecursiveUnion",
+    ("ExecRecursiveUnion",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("RecursiveUnionState"),
          Feature("Plan")
      ]),
-    ("nodeResult", "ExecResult",
+    ("ExecResult",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("ResultState"),
          Feature("Plan")
      ]),
-    ("nodeSamplescan", "ExecSampleScan",
+    ("ExecSampleScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("SampleScanState"),
          Feature("Plan")
      ]),
-    ("nodeSeqscan", "ExecSeqScan",
+    ("ExecSeqScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("SeqScanState"),
          Feature("Plan")
      ]),
-    ("nodeSetOp", "ExecSetOp",
+    ("ExecSetOp",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("SetOpState"),
          Feature("Plan")
      ]),
-    ("nodeSort", "ExecSort",
+    ("ExecSort",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("SortState"),
          Feature("Plan")
      ]),
-    ("nodeSubplan", "ExecSubPlan",
+    ("ExecSubPlan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("SubPlan"),
          Feature("Plan")
      ]),
-    ("nodeSubqueryscan", "ExecSubqueryScan",
+    ("ExecSubqueryScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("SubqueryScanState"),
          Feature("Plan")
      ]),
-    ("nodeTableFuncscan", "ExecTableFuncScan",
+    ("ExecTableFuncScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("TableFuncScanState"),
          Feature("Plan")
      ]),
-    ("nodeTidscan", "ExecTidScan",
+    ("ExecTidScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("TidScanState"),
          Feature("Plan")
      ]),
-    ("nodeUnique", "ExecUnique",
+    ("ExecUnique",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("UniqueState"),
          Feature("Plan")
      ]),
-    ("nodeValuesscan", "ExecValuesScan",
+    ("ExecValuesScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("ValuesScanState"),
          Feature("Plan")
      ]),
-    ("nodeWindowAgg", "ExecWindowAgg",
+    ("ExecWindowAgg",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("WindowAggState"),
          Feature("Plan")
      ]),
-    ("nodeWorktablescan", "ExecWorkTableScan",
+    ("ExecWorkTableScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("WorkTableScanState"),
@@ -378,14 +378,11 @@ class OperatingUnit:
 
     Parameters
     ----------
-    operator : str
-        The name of the PostgreSQL operator.
     function : str
         The name of the PostgreSQL function emitting the features.
     features_list : List[Feature]
         A list of features.
     """
-    operator: str  # TODO(Matt): remove?
     function: str
     features_list: List[Feature]
 
@@ -494,7 +491,7 @@ class Model:
     def __init__(self):
         nodes = clang_parser.ClangParser()
         operating_units = []
-        for operator, postgres_function, features in OU_DEFS:
+        for postgres_function, features in OU_DEFS:
             feature_list = []
             for feature in features:
                 # If an explicit list of BPF fields were specified,
@@ -518,7 +515,7 @@ class Model:
                                       readarg_p=True)
                 feature_list.append(new_feature)
 
-            new_ou = OperatingUnit(operator, postgres_function, feature_list)
+            new_ou = OperatingUnit(postgres_function, feature_list)
             operating_units.append(new_ou)
 
         self.operating_units = operating_units

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -317,12 +317,12 @@ class OperatingUnit:
     features_list : List[Feature]
         A list of features.
     """
-    operator: str
+    operator: str  # TODO(Matt): remove?
     function: str
     features_list: List[Feature]
 
     def name(self) -> str:
-        return self.operator + '_' + self.function
+        return self.function
 
     def begin_marker(self) -> str:
         return self.name() + '_begin'

--- a/cmudb/tscout/tscout.c
+++ b/cmudb/tscout/tscout.c
@@ -6,26 +6,26 @@ struct postmaster_event_t {
   int socket_fd_;
 };
 
-void postmaster_fork_backend(struct pt_regs *ctx) {
+void fork_backend(struct pt_regs *ctx) {
   struct postmaster_event_t event = {.type_ = 0};
   bpf_usdt_readarg(1, ctx, &(event.pid_));
   bpf_usdt_readarg(2, ctx, &(event.socket_fd_));
   postmaster_events.perf_submit(ctx, &event, sizeof(event));
 }
 
-void postmaster_fork_background(struct pt_regs *ctx) {
+void fork_background(struct pt_regs *ctx) {
   struct postmaster_event_t event = {.type_ = 1};
   bpf_usdt_readarg(1, ctx, &(event.pid_));
   postmaster_events.perf_submit(ctx, &event, sizeof(event));
 }
 
-void postmaster_reap_backend(struct pt_regs *ctx) {
+void reap_backend(struct pt_regs *ctx) {
   struct postmaster_event_t event = {.type_ = 2};
   bpf_usdt_readarg(1, ctx, &(event.pid_));
   postmaster_events.perf_submit(ctx, &event, sizeof(event));
 }
 
-void postmaster_reap_background(struct pt_regs *ctx) {
+void reap_background(struct pt_regs *ctx) {
   struct postmaster_event_t event = {.type_ = 3};
   bpf_usdt_readarg(1, ctx, &(event.pid_));
   postmaster_events.perf_submit(ctx, &event, sizeof(event));

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -117,8 +117,6 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     if socket_fd:
         cflags.append('-DCLIENT_SOCKET_FD={}'.format(socket_fd))
 
-    print(collector_c)
-
     collector_bpf = BPF(text=collector_c,
                         usdt_contexts=[collector_probes],
                         cflags=cflags)
@@ -254,8 +252,8 @@ if __name__ == '__main__':
 
     # Attach USDT probes to the target PID.
     tscout_probes = USDT(pid=int(pid))
-    for probe in ['postmaster_fork_backend', 'postmaster_fork_background',
-                  'postmaster_reap_backend', 'postmaster_reap_background']:
+    for probe in ['fork_backend', 'fork_background',
+                  'reap_backend', 'reap_background']:
         tscout_probes.enable_probe(probe=probe, fn_name=probe)
 
     # Load TScout program to monitor the Postmaster.

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -68,7 +68,7 @@ def generate_markers(operation, ou_index):
 
     # Replace OU-specific placeholders in C code.
     markers_c = markers_c.replace("SUBST_OU",
-                                  f'{operation.operator}_{operation.function}')
+                                  f'{operation.function}')
     markers_c = markers_c.replace("SUBST_READARGS",
                                   generate_readargs(operation.features_list))
     markers_c = markers_c.replace("SUBST_FEATURES",
@@ -116,6 +116,8 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     cflags = ['-DKBUILD_MODNAME="collector"']
     if socket_fd:
         cflags.append('-DCLIENT_SOCKET_FD={}'.format(socket_fd))
+
+    print(collector_c)
 
     collector_bpf = BPF(text=collector_c,
                         usdt_contexts=[collector_probes],

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -256,7 +256,7 @@
 #include "optimizer/optimizer.h"
 #include "parser/parse_agg.h"
 #include "parser/parse_coerce.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
@@ -2188,22 +2188,7 @@ _ExecAgg(PlanState *pstate)
 	return NULL;
 }
 
-static TupleTableSlot *
-ExecAgg(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeAgg_ExecAgg_begin);
-
-  result = _ExecAgg(pstate);
-
-  TS_MARKER(nodeAgg_ExecAgg_end);
-  TS_FEATURES_MARKER(nodeAgg_ExecAgg_features, castNode(AggState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(Agg)
 
 /*
  * ExecAgg for non-hashed case

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -2156,7 +2156,7 @@ lookup_hash_entries(AggState *aggstate)
  *	  the result tuple.
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecAgg(PlanState *pstate)
+WrappedExecAgg(PlanState *pstate)
 {
 	AggState   *node = castNode(AggState, pstate);
 	TupleTableSlot *result = NULL;

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -64,7 +64,7 @@
 #include "miscadmin.h"
 #include "pgstat.h"
 #include "storage/latch.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 
 /* Shared state for parallel-aware Append. */
 struct ParallelAppendState
@@ -383,22 +383,7 @@ _ExecAppend(PlanState *pstate)
 			return ExecClearTuple(node->ps.ps_ResultTupleSlot);
 	}
 }
-static TupleTableSlot *
-ExecAppend(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeAppend_ExecAppend_begin);
-
-  result = _ExecAppend(pstate);
-
-  TS_MARKER(nodeAppend_ExecAppend_end);
-  TS_FEATURES_MARKER(nodeAppend_ExecAppend_features, castNode(AppendState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(Append)
 
 /* ----------------------------------------------------------------
  *		ExecEndAppend

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -295,7 +295,7 @@ ExecInitAppend(Append *node, EState *estate, int eflags)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecAppend(PlanState *pstate)
+WrappedExecAppend(PlanState *pstate)
 {
 	AppendState *node = castNode(AppendState, pstate);
 	TupleTableSlot *result;

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -18,7 +18,7 @@
 #include "executor/execdebug.h"
 #include "executor/nodeCtescan.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 
 static TupleTableSlot *CteScanNext(CteScanState *node);
 
@@ -167,23 +167,7 @@ _ExecCteScan(PlanState *pstate)
 					(ExecScanRecheckMtd) CteScanRecheck);
 }
 
-static TupleTableSlot *
-ExecCteScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeCtescan_ExecCteScan_begin);
-
-  result = _ExecCteScan(pstate);
-
-  TS_MARKER(nodeCtescan_ExecCteScan_end);
-  TS_FEATURES_MARKER(nodeCtescan_ExecCteScan_features, castNode(CteScanState, pstate), pstate);
-
-  return result;
-}
-
+TS_EXECUTOR_WRAPPER(CteScan)
 
 /* ----------------------------------------------------------------
  *		ExecInitCteScan

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -158,7 +158,7 @@ CteScanRecheck(CteScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecCteScan(PlanState *pstate)
+WrappedExecCteScan(PlanState *pstate)
 {
 	CteScanState *node = castNode(CteScanState, pstate);
 

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -106,7 +106,7 @@ ExecInitCustomScan(CustomScan *cscan, EState *estate, int eflags)
 }
 
 static pg_attribute_always_inline TupleTableSlot *
-_ExecCustomScan(PlanState *pstate)
+WrappedExecCustomScan(PlanState *pstate)
 {
 	CustomScanState *node = castNode(CustomScanState, pstate);
 

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -18,7 +18,7 @@
 #include "nodes/extensible.h"
 #include "nodes/plannodes.h"
 #include "parser/parsetree.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/hsearch.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
@@ -116,22 +116,7 @@ _ExecCustomScan(PlanState *pstate)
 	return node->methods->ExecCustomScan(node);
 }
 
-static TupleTableSlot *
-ExecCustomScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeCustom_ExecCustomScan_begin);
-
-  result = _ExecCustomScan(pstate);
-
-  TS_MARKER(nodeCustom_ExecCustomScan_end);
-  TS_FEATURES_MARKER(nodeCustom_ExecCustomScan_features, castNode(CustomScanState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(CustomScan)
 
 void
 ExecEndCustomScan(CustomScanState *node)

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -25,7 +25,7 @@
 #include "executor/executor.h"
 #include "executor/nodeForeignscan.h"
 #include "foreign/fdwapi.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
 
@@ -128,22 +128,7 @@ _ExecForeignScan(PlanState *pstate)
 					(ExecScanRecheckMtd) ForeignRecheck);
 }
 
-static TupleTableSlot *
-ExecForeignScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeForeignscan_ExecForeignScan_begin);
-
-  result = _ExecForeignScan(pstate);
-
-  TS_MARKER(nodeForeignscan_ExecForeignScan_end);
-  TS_FEATURES_MARKER(nodeForeignscan_ExecForeignScan_features, castNode(ForeignScanState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(ForeignScan)
 
 /* ----------------------------------------------------------------
  *		ExecInitForeignScan

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -119,7 +119,7 @@ ForeignRecheck(ForeignScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecForeignScan(PlanState *pstate)
+WrappedExecForeignScan(PlanState *pstate)
 {
 	ForeignScanState *node = castNode(ForeignScanState, pstate);
 

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -264,7 +264,7 @@ FunctionRecheck(FunctionScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecFunctionScan(PlanState *pstate)
+WrappedExecFunctionScan(PlanState *pstate)
 {
 	FunctionScanState *node = castNode(FunctionScanState, pstate);
 

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -26,7 +26,7 @@
 #include "executor/nodeFunctionscan.h"
 #include "funcapi.h"
 #include "nodes/nodeFuncs.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/builtins.h"
 #include "utils/memutils.h"
 
@@ -273,22 +273,7 @@ _ExecFunctionScan(PlanState *pstate)
 					(ExecScanRecheckMtd) FunctionRecheck);
 }
 
-static TupleTableSlot *
-ExecFunctionScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeFunctionscan_ExecFunctionScan_begin);
-
-  result = _ExecFunctionScan(pstate);
-
-  TS_MARKER(nodeFunctionscan_ExecFunctionScan_end);
-  TS_FEATURES_MARKER(nodeFunctionscan_ExecFunctionScan_features, castNode(FunctionScanState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(FunctionScan)
 
 /* ----------------------------------------------------------------
  *		ExecInitFunctionScan

--- a/src/backend/executor/nodeGather.c
+++ b/src/backend/executor/nodeGather.c
@@ -40,7 +40,7 @@
 #include "miscadmin.h"
 #include "optimizer/optimizer.h"
 #include "pgstat.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
 
@@ -240,22 +240,7 @@ _ExecGather(PlanState *pstate)
 	return ExecProject(node->ps.ps_ProjInfo);
 }
 
-static TupleTableSlot *
-ExecGather(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeGather_ExecGather_begin);
-
-  result = _ExecGather(pstate);
-
-  TS_MARKER(nodeGather_ExecGather_end);
-  TS_FEATURES_MARKER(nodeGather_ExecGather_features, castNode(GatherState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(Gather)
 
 /* ----------------------------------------------------------------
  *		ExecEndGather

--- a/src/backend/executor/nodeGather.c
+++ b/src/backend/executor/nodeGather.c
@@ -140,7 +140,7 @@ ExecInitGather(Gather *node, EState *estate, int eflags)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecGather(PlanState *pstate)
+WrappedExecGather(PlanState *pstate)
 {
 	GatherState *node = castNode(GatherState, pstate);
 	TupleTableSlot *slot;

--- a/src/backend/executor/nodeGatherMerge.c
+++ b/src/backend/executor/nodeGatherMerge.c
@@ -186,7 +186,7 @@ ExecInitGatherMerge(GatherMerge *node, EState *estate, int eflags)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecGatherMerge(PlanState *pstate)
+WrappedExecGatherMerge(PlanState *pstate)
 {
 	GatherMergeState *node = castNode(GatherMergeState, pstate);
 	TupleTableSlot *slot;

--- a/src/backend/executor/nodeGatherMerge.c
+++ b/src/backend/executor/nodeGatherMerge.c
@@ -24,7 +24,7 @@
 #include "lib/binaryheap.h"
 #include "miscadmin.h"
 #include "optimizer/optimizer.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
 
@@ -280,22 +280,7 @@ _ExecGatherMerge(PlanState *pstate)
 	return ExecProject(node->ps.ps_ProjInfo);
 }
 
-static TupleTableSlot *
-ExecGatherMerge(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeGatherMerge_ExecGatherMerge_begin);
-
-  result = _ExecGatherMerge(pstate);
-
-  TS_MARKER(nodeGatherMerge_ExecGatherMerge_end);
-  TS_FEATURES_MARKER(nodeGatherMerge_ExecGatherMerge_features, castNode(GatherMergeState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(GatherMerge)
 
 /* ----------------------------------------------------------------
  *		ExecEndGatherMerge

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -35,7 +35,7 @@
  *		Return one tuple for each group of matching input tuples.
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecGroup(PlanState *pstate)
+WrappedExecGroup(PlanState *pstate)
 {
 	GroupState *node = castNode(GroupState, pstate);
 	ExprContext *econtext;

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -25,7 +25,7 @@
 #include "executor/executor.h"
 #include "executor/nodeGroup.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 
 
@@ -152,22 +152,7 @@ _ExecGroup(PlanState *pstate)
 	}
 }
 
-static TupleTableSlot *
-ExecGroup(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeGroup_ExecGroup_begin);
-
-  result = _ExecGroup(pstate);
-
-  TS_MARKER(nodeGroup_ExecGroup_end);
-  TS_FEATURES_MARKER(nodeGroup_ExecGroup_features, castNode(GroupState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(Group)
 
 /* -----------------
  * ExecInitGroup

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -579,15 +579,17 @@ _ExecHashJoinImpl(PlanState *pstate, bool parallel)
 static pg_attribute_always_inline TupleTableSlot *
 ExecHashJoinImpl(PlanState *pstate, bool parallel) {
   TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeHashjoin_ExecHashJoinImpl_begin);
+  TS_MARKER(ExecHashJoinImpl_begin);
 
   result = _ExecHashJoinImpl(pstate, parallel);
 
-  TS_MARKER(nodeHashjoin_ExecHashJoinImpl_end);
-  TS_FEATURES_MARKER(nodeHashjoin_ExecHashJoinImpl_features, castNode(HashJoinState, pstate), pstate);
+  TS_MARKER(ExecHashJoinImpl_end);
+  TS_MARKER(
+	ExecHashJoinImpl_features,
+    pstate->state->es_plannedstmt->queryId,
+    castNode(HashJoinState, pstate),
+    pstate->plan
+  );
 
   return result;
 }

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -163,7 +163,7 @@ static void ExecParallelHashJoinPartitionOuter(HashJoinState *node);
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecHashJoinImpl(PlanState *pstate, bool parallel)
+WrappedExecHashJoinImpl(PlanState *pstate, bool parallel)
 {
 	HashJoinState *node = castNode(HashJoinState, pstate);
 	PlanState  *outerNode;
@@ -581,7 +581,7 @@ ExecHashJoinImpl(PlanState *pstate, bool parallel) {
   TupleTableSlot *result;
   TS_MARKER(ExecHashJoinImpl_begin);
 
-  result = _ExecHashJoinImpl(pstate, parallel);
+  result = WrappedExecHashJoinImpl(pstate, parallel);
 
   TS_MARKER(ExecHashJoinImpl_end);
   TS_MARKER(

--- a/src/backend/executor/nodeIncrementalSort.c
+++ b/src/backend/executor/nodeIncrementalSort.c
@@ -82,7 +82,7 @@
 #include "executor/execdebug.h"
 #include "executor/nodeIncrementalSort.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/lsyscache.h"
 #include "utils/tuplesort.h"
 
@@ -965,22 +965,7 @@ _ExecIncrementalSort(PlanState *pstate)
 	return slot;
 }
 
-static TupleTableSlot *
-ExecIncrementalSort(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeIncrementalSort_ExecIncrementalSort_begin);
-
-  result = _ExecIncrementalSort(pstate);
-
-  TS_MARKER(nodeIncrementalSort_ExecIncrementalSort_end);
-  TS_FEATURES_MARKER(nodeIncrementalSort_ExecIncrementalSort_features, castNode(IncrementalSortState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(IncrementalSort)
 
 /* ----------------------------------------------------------------
  *		ExecInitIncrementalSort

--- a/src/backend/executor/nodeIncrementalSort.c
+++ b/src/backend/executor/nodeIncrementalSort.c
@@ -494,7 +494,7 @@ switchToPresortedPrefixMode(PlanState *pstate)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecIncrementalSort(PlanState *pstate)
+WrappedExecIncrementalSort(PlanState *pstate)
 {
 	IncrementalSortState *node = castNode(IncrementalSortState, pstate);
 	EState	   *estate;

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -41,7 +41,7 @@
 #include "miscadmin.h"
 #include "storage/bufmgr.h"
 #include "storage/predicate.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 #include "utils/rel.h"
 
@@ -320,22 +320,7 @@ _ExecIndexOnlyScan(PlanState *pstate)
 					(ExecScanRecheckMtd) IndexOnlyRecheck);
 }
 
-static TupleTableSlot *
-ExecIndexOnlyScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_begin);
-
-  result = _ExecIndexOnlyScan(pstate);
-
-  TS_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_end);
-  TS_FEATURES_MARKER(nodeIndexonlyscan_ExecIndexOnlyScan_features, castNode(IndexOnlyScanState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(IndexOnlyScan)
 
 /* ----------------------------------------------------------------
  *		ExecReScanIndexOnlyScan(node)

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -305,7 +305,7 @@ IndexOnlyRecheck(IndexOnlyScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecIndexOnlyScan(PlanState *pstate)
+WrappedExecIndexOnlyScan(PlanState *pstate)
 {
 	IndexOnlyScanState *node = castNode(IndexOnlyScanState, pstate);
 

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -38,7 +38,7 @@
 #include "lib/pairingheap.h"
 #include "miscadmin.h"
 #include "nodes/nodeFuncs.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/array.h"
 #include "utils/datum.h"
 #include "utils/lsyscache.h"
@@ -540,22 +540,7 @@ _ExecIndexScan(PlanState *pstate)
 						(ExecScanRecheckMtd) IndexRecheck);
 }
 
-static TupleTableSlot *
-ExecIndexScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeIndexscan_ExecIndexScan_begin);
-
-  result = _ExecIndexScan(pstate);
-
-  TS_MARKER(nodeIndexscan_ExecIndexScan_end);
-  TS_FEATURES_MARKER(nodeIndexscan_ExecIndexScan_features, castNode(IndexScanState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(IndexScan)
 
 /* ----------------------------------------------------------------
  *		ExecReScanIndexScan(node)

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -520,7 +520,7 @@ reorderqueue_pop(IndexScanState *node)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecIndexScan(PlanState *pstate)
+WrappedExecIndexScan(PlanState *pstate)
 {
 	IndexScanState *node = castNode(IndexScanState, pstate);
 

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -25,7 +25,7 @@
 #include "executor/nodeLimit.h"
 #include "miscadmin.h"
 #include "nodes/nodeFuncs.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 
 static void recompute_limits(LimitState *node);
 static int64 compute_tuples_needed(LimitState *node);
@@ -346,21 +346,7 @@ _ExecLimit(PlanState *pstate)
 	return slot;
 }
 
-static TupleTableSlot *			/* return: a tuple or NULL */
-ExecLimit(PlanState *pstate) {
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeLimit_ExecLimit_begin);
-
-  result = _ExecLimit(pstate);
-
-  TS_MARKER(nodeLimit_ExecLimit_end);
-  TS_FEATURES_MARKER(nodeLimit_ExecLimit_features, castNode(LimitState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(Limit)
 
 /*
  * Evaluate the limit/offset expressions --- done at startup or rescan.

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -39,7 +39,7 @@ static int64 compute_tuples_needed(LimitState *node);
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *			/* return: a tuple or NULL */
-_ExecLimit(PlanState *pstate)
+WrappedExecLimit(PlanState *pstate)
 {
 	LimitState *node = castNode(LimitState, pstate);
 	ExprContext *econtext = node->ps.ps_ExprContext;

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -36,7 +36,7 @@
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *			/* return: a tuple or NULL */
-_ExecLockRows(PlanState *pstate)
+WrappedExecLockRows(PlanState *pstate)
 {
 	LockRowsState *node = castNode(LockRowsState, pstate);
 	TupleTableSlot *slot;

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -27,7 +27,7 @@
 #include "executor/nodeLockRows.h"
 #include "foreign/fdwapi.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/rel.h"
 
 
@@ -282,22 +282,7 @@ lnext:
 	return slot;
 }
 
-static TupleTableSlot *
-ExecLockRows(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeLockRows_ExecLockRows_begin);
-
-  result = _ExecLockRows(pstate);
-
-  TS_MARKER(nodeLockRows_ExecLockRows_end);
-  TS_FEATURES_MARKER(nodeLockRows_ExecLockRows_features, castNode(LockRowsState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(LockRows)
 
 /* ----------------------------------------------------------------
  *		ExecInitLockRows

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -24,7 +24,7 @@
 #include "executor/executor.h"
 #include "executor/nodeMaterial.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 
 /* ----------------------------------------------------------------
  *		ExecMaterial
@@ -157,22 +157,7 @@ _ExecMaterial(PlanState *pstate)
 	return ExecClearTuple(slot);
 }
 
-static TupleTableSlot *
-ExecMaterial(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeMaterial_ExecMaterial_begin);
-
-  result = _ExecMaterial(pstate);
-
-  TS_MARKER(nodeMaterial_ExecMaterial_end);
-  TS_FEATURES_MARKER(nodeMaterial_ExecMaterial_features, castNode(MaterialState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(Material)
 
 /* ----------------------------------------------------------------
  *		ExecInitMaterial

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -37,7 +37,7 @@
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *			/* result tuple from subplan */
-_ExecMaterial(PlanState *pstate)
+WrappedExecMaterial(PlanState *pstate)
 {
 	MaterialState *node = castNode(MaterialState, pstate);
 	EState	   *estate;

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -210,7 +210,7 @@ ExecInitMergeAppend(MergeAppend *node, EState *estate, int eflags)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecMergeAppend(PlanState *pstate)
+WrappedExecMergeAppend(PlanState *pstate)
 {
 	MergeAppendState *node = castNode(MergeAppendState, pstate);
 	TupleTableSlot *result;

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -43,7 +43,7 @@
 #include "executor/nodeMergeAppend.h"
 #include "lib/binaryheap.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 
 /*
  * We have one slot for each item in the heap array.  We use SlotNumber
@@ -279,22 +279,7 @@ _ExecMergeAppend(PlanState *pstate)
 	return result;
 }
 
-static TupleTableSlot *
-ExecMergeAppend(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeMergeAppend_ExecMergeAppend_begin);
-
-  result = _ExecMergeAppend(pstate);
-
-  TS_MARKER(nodeMergeAppend_ExecMergeAppend_end);
-  TS_FEATURES_MARKER(nodeMergeAppend_ExecMergeAppend_features, castNode(MergeAppendState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(MergeAppend)
 
 /*
  * Compare the tuples in the two given slots.

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -96,7 +96,7 @@
 #include "executor/execdebug.h"
 #include "executor/nodeMergejoin.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
 
@@ -1429,22 +1429,7 @@ _ExecMergeJoin(PlanState *pstate)
 	}
 }
 
-static TupleTableSlot *
-ExecMergeJoin(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeMergejoin_ExecMergeJoin_begin);
-
-  result = _ExecMergeJoin(pstate);
-
-  TS_MARKER(nodeMergejoin_ExecMergeJoin_end);
-  TS_FEATURES_MARKER(nodeMergejoin_ExecMergeJoin_features, castNode(MergeJoinState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(MergeJoin)
 
 /* ----------------------------------------------------------------
  *		ExecInitMergeJoin

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -598,7 +598,7 @@ ExecMergeTupleDump(MergeJoinState *mergestate)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecMergeJoin(PlanState *pstate)
+WrappedExecMergeJoin(PlanState *pstate)
 {
 	MergeJoinState *node = castNode(MergeJoinState, pstate);
 	ExprState  *joinqual;

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -48,7 +48,7 @@
 #include "rewrite/rewriteHandler.h"
 #include "storage/bufmgr.h"
 #include "storage/lmgr.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
 #include "utils/memutils.h"
@@ -2646,22 +2646,7 @@ _ExecModifyTable(PlanState *pstate)
 	return NULL;
 }
 
-static TupleTableSlot *
-ExecModifyTable(PlanState *pstate)
-{
-    TupleTableSlot *result;
-    TS_MARKER_SETUP();
-
-    result = NULL;
-    TS_MARKER(nodeModifyTable_ExecModifyTable_begin);
-
-    result = _ExecModifyTable(pstate);
-
-    TS_MARKER(nodeModifyTable_ExecModifyTable_end);
-    TS_FEATURES_MARKER(nodeModifyTable_ExecModifyTable_features, castNode(ModifyTableState, pstate), pstate);
-
-    return result;
-}
+TS_EXECUTOR_WRAPPER(ModifyTable)
 
 /*
  * ExecLookupResultRelByOid

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2347,7 +2347,7 @@ ExecPrepareTupleRouting(ModifyTableState *mtstate,
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecModifyTable(PlanState *pstate)
+WrappedExecModifyTable(PlanState *pstate)
 {
 	ModifyTableState *node = castNode(ModifyTableState, pstate);
 	EState	   *estate = node->ps.state;

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -18,7 +18,7 @@
 #include "executor/execdebug.h"
 #include "executor/nodeNamedtuplestorescan.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/queryenvironment.h"
 
 static TupleTableSlot *NamedTuplestoreScanNext(NamedTuplestoreScanState *node);
@@ -75,23 +75,7 @@ _ExecNamedTuplestoreScan(PlanState *pstate)
 					(ExecScanRecheckMtd) NamedTuplestoreScanRecheck);
 }
 
-static TupleTableSlot *
-ExecNamedTuplestoreScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_begin);
-
-  result = _ExecNamedTuplestoreScan(pstate);
-
-  TS_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_end);
-  TS_FEATURES_MARKER(nodeNamedtuplestorescan_ExecNamedTuplestoreScan_features, castNode(NamedTuplestoreScanState, pstate), pstate);
-
-  return result;
-}
-
+TS_EXECUTOR_WRAPPER(NamedTuplestoreScan)
 
 /* ----------------------------------------------------------------
  *		ExecInitNamedTuplestoreScan

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -66,7 +66,7 @@ NamedTuplestoreScanRecheck(NamedTuplestoreScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecNamedTuplestoreScan(PlanState *pstate)
+WrappedExecNamedTuplestoreScan(PlanState *pstate)
 {
 	NamedTuplestoreScanState *node = castNode(NamedTuplestoreScanState, pstate);
 

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -24,7 +24,7 @@
 #include "executor/execdebug.h"
 #include "executor/nodeNestloop.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 
 
@@ -256,22 +256,7 @@ _ExecNestLoop(PlanState *pstate)
 	}
 }
 
-static TupleTableSlot *
-ExecNestLoop(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeNestloop_ExecNestLoop_begin);
-
-  result = _ExecNestLoop(pstate);
-
-  TS_MARKER(nodeNestloop_ExecNestLoop_end);
-  TS_FEATURES_MARKER(nodeNestloop_ExecNestLoop_features, castNode(NestLoopState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(NestLoop)
 
 /* ----------------------------------------------------------------
  *		ExecInitNestLoop

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -59,7 +59,7 @@
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecNestLoop(PlanState *pstate)
+WrappedExecNestLoop(PlanState *pstate)
 {
 	NestLoopState *node = castNode(NestLoopState, pstate);
 	NestLoop   *nl;

--- a/src/backend/executor/nodeProjectSet.c
+++ b/src/backend/executor/nodeProjectSet.c
@@ -26,7 +26,7 @@
 #include "executor/nodeProjectSet.h"
 #include "miscadmin.h"
 #include "nodes/nodeFuncs.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 
 
@@ -117,22 +117,7 @@ _ExecProjectSet(PlanState *pstate)
 	return NULL;
 }
 
-static TupleTableSlot *
-ExecProjectSet(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeProjectSet_ExecProjectSet_begin);
-
-  result = _ExecProjectSet(pstate);
-
-  TS_MARKER(nodeProjectSet_ExecProjectSet_end);
-  TS_FEATURES_MARKER(nodeProjectSet_ExecProjectSet_features, castNode(ProjectSetState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(ProjectSet)
 
 /* ----------------------------------------------------------------
  *		ExecProjectSRF

--- a/src/backend/executor/nodeProjectSet.c
+++ b/src/backend/executor/nodeProjectSet.c
@@ -41,7 +41,7 @@ static TupleTableSlot *ExecProjectSRF(ProjectSetState *node, bool continuing);
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecProjectSet(PlanState *pstate)
+WrappedExecProjectSet(PlanState *pstate)
 {
 	ProjectSetState *node = castNode(ProjectSetState, pstate);
 	TupleTableSlot *outerTupleSlot;

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -21,7 +21,7 @@
 #include "executor/execdebug.h"
 #include "executor/nodeRecursiveunion.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 
 
@@ -160,22 +160,7 @@ _ExecRecursiveUnion(PlanState *pstate)
 	return NULL;
 }
 
-static TupleTableSlot *
-ExecRecursiveUnion(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeRecursiveunion_ExecRecursiveUnion_begin);
-
-  result = _ExecRecursiveUnion(pstate);
-
-  TS_MARKER(nodeRecursiveunion_ExecRecursiveUnion_end);
-  TS_FEATURES_MARKER(nodeRecursiveunion_ExecRecursiveUnion_features, castNode(RecursiveUnionState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(RecursiveUnion)
 
 /* ----------------------------------------------------------------
  *		ExecInitRecursiveUnion

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -73,7 +73,7 @@ build_hash_table(RecursiveUnionState *rustate)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecRecursiveUnion(PlanState *pstate)
+WrappedExecRecursiveUnion(PlanState *pstate)
 {
 	RecursiveUnionState *node = castNode(RecursiveUnionState, pstate);
 	PlanState  *outerPlan = outerPlanState(node);

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -66,7 +66,7 @@
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecResult(PlanState *pstate)
+WrappedExecResult(PlanState *pstate)
 {
 	ResultState *node = castNode(ResultState, pstate);
 	TupleTableSlot *outerTupleSlot;

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -48,7 +48,7 @@
 #include "executor/executor.h"
 #include "executor/nodeResult.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 
 
@@ -140,22 +140,7 @@ _ExecResult(PlanState *pstate)
 	return NULL;
 }
 
-static TupleTableSlot *
-ExecResult(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeResult_ExecResult_begin);
-
-  result = _ExecResult(pstate);
-
-  TS_MARKER(nodeResult_ExecResult_end);
-  TS_FEATURES_MARKER(nodeResult_ExecResult_features, castNode(ResultState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(Result)
 
 /* ----------------------------------------------------------------
  *		ExecResultMarkPos

--- a/src/backend/executor/nodeSamplescan.c
+++ b/src/backend/executor/nodeSamplescan.c
@@ -23,7 +23,7 @@
 #include "pgstat.h"
 #include "storage/bufmgr.h"
 #include "storage/predicate.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/builtins.h"
 #include "utils/rel.h"
 
@@ -89,22 +89,7 @@ _ExecSampleScan(PlanState *pstate)
 					(ExecScanRecheckMtd) SampleRecheck);
 }
 
-static TupleTableSlot *
-ExecSampleScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeSamplescan_ExecSampleScan_begin);
-
-  result = _ExecSampleScan(pstate);
-
-  TS_MARKER(nodeSamplescan_ExecSampleScan_end);
-  TS_FEATURES_MARKER(nodeSamplescan_ExecSampleScan_features, castNode(SampleScanState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(SampleScan)
 
 /* ----------------------------------------------------------------
  *		ExecInitSampleScan

--- a/src/backend/executor/nodeSamplescan.c
+++ b/src/backend/executor/nodeSamplescan.c
@@ -80,7 +80,7 @@ SampleRecheck(SampleScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecSampleScan(PlanState *pstate)
+WrappedExecSampleScan(PlanState *pstate)
 {
 	SampleScanState *node = castNode(SampleScanState, pstate);
 

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -106,7 +106,7 @@ SeqRecheck(SeqScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecSeqScan(PlanState *pstate)
+WrappedExecSeqScan(PlanState *pstate)
 {
 	SeqScanState *node = castNode(SeqScanState, pstate);
 

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -31,7 +31,7 @@
 #include "access/tableam.h"
 #include "executor/execdebug.h"
 #include "executor/nodeSeqscan.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/rel.h"
 
 static TupleTableSlot *SeqNext(SeqScanState *node);
@@ -115,23 +115,7 @@ _ExecSeqScan(PlanState *pstate)
 					(ExecScanRecheckMtd) SeqRecheck);
 }
 
-static TupleTableSlot *
-ExecSeqScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeSeqscan_ExecSeqScan_begin);
-
-  result = _ExecSeqScan(pstate);
-
-  TS_MARKER(nodeSeqscan_ExecSeqScan_end);
-  TS_FEATURES_MARKER(nodeSeqscan_ExecSeqScan_features, castNode(SeqScanState, pstate), pstate);
-
-  return result;
-}
-
+TS_EXECUTOR_WRAPPER(SeqScan)
 
 /* ----------------------------------------------------------------
  *		ExecInitSeqScan

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -188,7 +188,7 @@ set_output_count(SetOpState *setopstate, SetOpStatePerGroup pergroup)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *			/* return: a tuple or NULL */
-_ExecSetOp(PlanState *pstate)
+WrappedExecSetOp(PlanState *pstate)
 {
 	SetOpState *node = castNode(SetOpState, pstate);
 	SetOp	   *plannode = (SetOp *) node->ps.plan;

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -48,7 +48,7 @@
 #include "executor/executor.h"
 #include "executor/nodeSetOp.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 
 
@@ -221,22 +221,7 @@ _ExecSetOp(PlanState *pstate)
 		return setop_retrieve_direct(node);
 }
 
-static TupleTableSlot *
-ExecSetOp(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeSetOp_ExecSetOp_begin);
-
-  result = _ExecSetOp(pstate);
-
-  TS_MARKER(nodeSetOp_ExecSetOp_end);
-  TS_FEATURES_MARKER(nodeSetOp_ExecSetOp_features, castNode(SetOpState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(SetOp)
 
 /*
  * ExecSetOp for non-hashed case

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -38,7 +38,7 @@
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecSort(PlanState *pstate)
+WrappedExecSort(PlanState *pstate)
 {
 	SortState  *node = castNode(SortState, pstate);
 	EState	   *estate;

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -19,7 +19,7 @@
 #include "executor/execdebug.h"
 #include "executor/nodeSort.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/tuplesort.h"
 
 
@@ -157,22 +157,7 @@ _ExecSort(PlanState *pstate)
 	return slot;
 }
 
-static TupleTableSlot *
-ExecSort(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeSort_ExecSort_begin);
-
-  result = _ExecSort(pstate);
-
-  TS_MARKER(nodeSort_ExecSort_end);
-  TS_FEATURES_MARKER(nodeSort_ExecSort_features, castNode(SortState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(Sort)
 
 /* ----------------------------------------------------------------
  *		ExecInitSort

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -60,7 +60,7 @@ static bool slotNoNulls(TupleTableSlot *slot);
  * ----------------------------------------------------------------
  */
 static Datum pg_attribute_always_inline
-_ExecSubPlan(SubPlanState *node,
+WrappedExecSubPlan(SubPlanState *node,
 			ExprContext *econtext,
 			bool *isNull)
 {
@@ -95,6 +95,10 @@ _ExecSubPlan(SubPlanState *node,
 	return retval;
 }
 
+/*
+ * The result type here is Datum instead of TupleTableSlot * like most executors, so we can't use the macro in
+ * tscout/executors.h and instead just reproduce the behavior. If tscout/executors.h changes, change this too.
+ */
 Datum
 ExecSubPlan(SubPlanState *node,
 			ExprContext *econtext,
@@ -103,7 +107,7 @@ ExecSubPlan(SubPlanState *node,
   Datum result;
   TS_MARKER(ExecSubPlan_begin);
 
-  result = _ExecSubPlan(node, econtext, isNull);
+  result = WrappedExecSubPlan(node, econtext, isNull);
 
   TS_MARKER(ExecSubPlan_end);
   TS_MARKER(

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -35,7 +35,7 @@
 #include "miscadmin.h"
 #include "nodes/makefuncs.h"
 #include "nodes/nodeFuncs.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/array.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
@@ -101,14 +101,17 @@ ExecSubPlan(SubPlanState *node,
 			bool *isNull)
 {
   Datum result;
-  TS_MARKER_SETUP();
-
-  TS_MARKER(nodeSubplan_ExecSubPlan_begin);
+  TS_MARKER(ExecSubPlan_begin);
 
   result = _ExecSubPlan(node, econtext, isNull);
 
-  TS_MARKER(nodeSubplan_ExecSubPlan_end);
-  TS_FEATURES_MARKER(nodeSubplan_ExecSubPlan_features, castNode(SubPlanState, node), node->planstate);
+  TS_MARKER(ExecSubPlan_end);
+  TS_MARKER(
+	ExecSubPlan_features,
+	node->planstate->state->es_plannedstmt->queryId,
+    castNode(SubPlanState, node),
+	node->planstate->plan
+  );
 
   return result;
 }

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -29,7 +29,7 @@
 
 #include "executor/execdebug.h"
 #include "executor/nodeSubqueryscan.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 
 static TupleTableSlot *SubqueryNext(SubqueryScanState *node);
 
@@ -90,22 +90,7 @@ _ExecSubqueryScan(PlanState *pstate)
 					(ExecScanRecheckMtd) SubqueryRecheck);
 }
 
-static TupleTableSlot *
-ExecSubqueryScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeSubqueryscan_ExecSubqueryScan_begin);
-
-  result = _ExecSubqueryScan(pstate);
-
-  TS_MARKER(nodeSubqueryscan_ExecSubqueryScan_end);
-  TS_FEATURES_MARKER(nodeSubqueryscan_ExecSubqueryScan_features, castNode(SubqueryScanState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(SubqueryScan)
 
 /* ----------------------------------------------------------------
  *		ExecInitSubqueryScan

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -81,7 +81,7 @@ SubqueryRecheck(SubqueryScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecSubqueryScan(PlanState *pstate)
+WrappedExecSubqueryScan(PlanState *pstate)
 {
 	SubqueryScanState *node = castNode(SubqueryScanState, pstate);
 

--- a/src/backend/executor/nodeTableFuncscan.c
+++ b/src/backend/executor/nodeTableFuncscan.c
@@ -27,7 +27,7 @@
 #include "executor/tablefunc.h"
 #include "miscadmin.h"
 #include "nodes/execnodes.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/builtins.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
@@ -103,22 +103,7 @@ _ExecTableFuncScan(PlanState *pstate)
 					(ExecScanRecheckMtd) TableFuncRecheck);
 }
 
-static TupleTableSlot *
-ExecTableFuncScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeTableFuncscan_ExecTableFuncScan_begin);
-
-  result = _ExecTableFuncScan(pstate);
-
-  TS_MARKER(nodeTableFuncscan_ExecTableFuncScan_end);
-  TS_FEATURES_MARKER(nodeTableFuncscan_ExecTableFuncScan_features, castNode(TableFuncScanState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(TableFuncScan)
 
 /* ----------------------------------------------------------------
  *		ExecInitTableFuncscan

--- a/src/backend/executor/nodeTableFuncscan.c
+++ b/src/backend/executor/nodeTableFuncscan.c
@@ -94,7 +94,7 @@ TableFuncRecheck(TableFuncScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecTableFuncScan(PlanState *pstate)
+WrappedExecTableFuncScan(PlanState *pstate)
 {
 	TableFuncScanState *node = castNode(TableFuncScanState, pstate);
 

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -31,7 +31,7 @@
 #include "miscadmin.h"
 #include "nodes/nodeFuncs.h"
 #include "storage/bufmgr.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/array.h"
 #include "utils/rel.h"
 
@@ -438,22 +438,7 @@ _ExecTidScan(PlanState *pstate)
 					(ExecScanRecheckMtd) TidRecheck);
 }
 
-static TupleTableSlot *
-ExecTidScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeTidscan_ExecTidScan_begin);
-
-  result = _ExecTidScan(pstate);
-
-  TS_MARKER(nodeTidscan_ExecTidScan_end);
-  TS_FEATURES_MARKER(nodeTidscan_ExecTidScan_features, castNode(TidScanState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(TidScan)
 
 /* ----------------------------------------------------------------
  *		ExecReScanTidScan(node)

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -429,7 +429,7 @@ TidRecheck(TidScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecTidScan(PlanState *pstate)
+WrappedExecTidScan(PlanState *pstate)
 {
 	TidScanState *node = castNode(TidScanState, pstate);
 

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -45,7 +45,7 @@
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *			/* return: a tuple or NULL */
-_ExecUnique(PlanState *pstate)
+WrappedExecUnique(PlanState *pstate)
 {
 	UniqueState *node = castNode(UniqueState, pstate);
 	ExprContext *econtext = node->ps.ps_ExprContext;

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -36,7 +36,7 @@
 #include "executor/executor.h"
 #include "executor/nodeUnique.h"
 #include "miscadmin.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 
 
@@ -105,22 +105,7 @@ _ExecUnique(PlanState *pstate)
 	return ExecCopySlot(resultTupleSlot, slot);
 }
 
-static TupleTableSlot *
-ExecUnique(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeUnique_ExecUnique_begin);
-
-  result = _ExecUnique(pstate);
-
-  TS_MARKER(nodeUnique_ExecUnique_end);
-  TS_FEATURES_MARKER(nodeUnique_ExecUnique_features, castNode(UniqueState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(Unique)
 
 /* ----------------------------------------------------------------
  *		ExecInitUnique

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -27,7 +27,7 @@
 #include "executor/nodeValuesscan.h"
 #include "jit/jit.h"
 #include "optimizer/clauses.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/expandeddatum.h"
 
 
@@ -204,22 +204,7 @@ _ExecValuesScan(PlanState *pstate)
 					(ExecScanRecheckMtd) ValuesRecheck);
 }
 
-static TupleTableSlot *
-ExecValuesScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeValuesscan_ExecValuesScan_begin);
-
-  result = _ExecValuesScan(pstate);
-
-  TS_MARKER(nodeValuesscan_ExecValuesScan_end);
-  TS_FEATURES_MARKER(nodeValuesscan_ExecValuesScan_features, castNode(ValuesScanState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(ValuesScan)
 
 /* ----------------------------------------------------------------
  *		ExecInitValuesScan

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -195,7 +195,7 @@ ValuesRecheck(ValuesScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecValuesScan(PlanState *pstate)
+WrappedExecValuesScan(PlanState *pstate)
 {
 	ValuesScanState *node = castNode(ValuesScanState, pstate);
 

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -44,7 +44,7 @@
 #include "optimizer/optimizer.h"
 #include "parser/parse_agg.h"
 #include "parser/parse_coerce.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/acl.h"
 #include "utils/builtins.h"
 #include "utils/datum.h"
@@ -2239,22 +2239,7 @@ _ExecWindowAgg(PlanState *pstate)
 	return ExecProject(winstate->ss.ps.ps_ProjInfo);
 }
 
-static TupleTableSlot *
-ExecWindowAgg(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeWindowAgg_ExecWindowAgg_begin);
-
-  result = _ExecWindowAgg(pstate);
-
-  TS_MARKER(nodeWindowAgg_ExecWindowAgg_end);
-  TS_FEATURES_MARKER(nodeWindowAgg_ExecWindowAgg_features, castNode(WindowAggState, pstate), pstate);
-
-  return result;
-}
+TS_EXECUTOR_WRAPPER(WindowAgg)
 
 /* -----------------
  * ExecInitWindowAgg

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -2021,7 +2021,7 @@ update_grouptailpos(WindowAggState *winstate)
  * -----------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecWindowAgg(PlanState *pstate)
+WrappedExecWindowAgg(PlanState *pstate)
 {
 	WindowAggState *winstate = castNode(WindowAggState, pstate);
 	ExprContext *econtext;

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -17,7 +17,7 @@
 
 #include "executor/execdebug.h"
 #include "executor/nodeWorktablescan.h"
-#include "tscout/marker.h"
+#include "tscout/executors.h"
 
 static TupleTableSlot *WorkTableScanNext(WorkTableScanState *node);
 
@@ -122,23 +122,7 @@ _ExecWorkTableScan(PlanState *pstate)
 					(ExecScanRecheckMtd) WorkTableScanRecheck);
 }
 
-static TupleTableSlot *
-ExecWorkTableScan(PlanState *pstate)
-{
-  TupleTableSlot *result;
-  TS_MARKER_SETUP();
-
-  result = NULL;
-  TS_MARKER(nodeWorktablescan_ExecWorkTableScan_begin);
-
-  result = _ExecWorkTableScan(pstate);
-
-  TS_MARKER(nodeWorktablescan_ExecWorkTableScan_end);
-  TS_FEATURES_MARKER(nodeWorktablescan_ExecWorkTableScan_features, castNode(WorkTableScanState, pstate), pstate);
-
-  return result;
-}
-
+TS_EXECUTOR_WRAPPER(WorkTableScan)
 
 /* ----------------------------------------------------------------
  *		ExecInitWorkTableScan

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -79,7 +79,7 @@ WorkTableScanRecheck(WorkTableScanState *node, TupleTableSlot *slot)
  * ----------------------------------------------------------------
  */
 static pg_attribute_always_inline TupleTableSlot *
-_ExecWorkTableScan(PlanState *pstate)
+WrappedExecWorkTableScan(PlanState *pstate)
 {
 	WorkTableScanState *node = castNode(WorkTableScanState, pstate);
 

--- a/src/backend/postmaster/postmaster.c
+++ b/src/backend/postmaster/postmaster.c
@@ -139,7 +139,7 @@
 
 #include "tscout/marker.h"
 
-TS_DEFINE_SEMAPHORE(postmaster_fork_backend);
+TS_DEFINE_SEMAPHORE(fork_backend);
 
 /*
  * Possible types of a backend. Beyond being the possible bkend_type values in
@@ -3219,7 +3219,7 @@ reaper(SIGNAL_ARGS)
 		/* Was it one of our background workers? */
 		if (CleanupBackgroundWorker(pid, exitstatus))
 		{
-			TS_MARKER(postmaster_reap_background, pid);
+			TS_MARKER(reap_background, pid);
 			/* have it be restarted */
 			HaveCrashedWorker = true;
 			continue;
@@ -3229,7 +3229,7 @@ reaper(SIGNAL_ARGS)
 		 * Else do standard backend child cleanup.
 		 */
 		CleanupBackend(pid, exitstatus);
-		TS_MARKER(postmaster_reap_backend, pid);
+		TS_MARKER(reap_backend, pid);
 	}							/* loop over pending child-death reports */
 
 	/*
@@ -4249,7 +4249,7 @@ BackendStartup(Port *port)
 		return STATUS_ERROR;
 	}
 
-	TS_MARKER_WITH_SEMAPHORE(postmaster_fork_backend, pid, port->sock);
+	TS_MARKER_WITH_SEMAPHORE(fork_backend, pid, port->sock);
 	/* in parent, successful fork */
 	ereport(DEBUG2,
 			(errmsg_internal("forked new backend, pid=%d socket=%d",
@@ -5860,7 +5860,7 @@ do_start_bgworker(RegisteredBgWorker *rw)
 #ifdef EXEC_BACKEND
 			ShmemBackendArrayAdd(rw->rw_backend);
 #endif
-			TS_MARKER(postmaster_fork_background, worker_pid);
+			TS_MARKER(fork_background, worker_pid);
 			return true;
 	}
 

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -2,18 +2,26 @@
 
 #include "tscout/marker.h"
 
+/*
+ * Wrapper to add TScout markers to an executor. In the executor file, rename the current Exec<blah> function to
+ * WrappedExec<blah> and then add TS_EXECUTOR_WRAPPER<blah> beneath it. See src/backend/executors for examples.
+ *
+ * There is a small list of executors that cannot use this macro due to function signature differences. If the macro
+ * below changes, be sure to update those executors as well. The current list is:
+ * src/backend/executors/nodeSubplan.c
+ */
 #define TS_EXECUTOR_WRAPPER(node_type)                                                                          \
 static TupleTableSlot *                                                                                         \
 Exec##node_type(PlanState *pstate)                                                                              \
 {                                                                                                               \
   TupleTableSlot *result;                                                                                       \
-  TS_MARKER(Exec##node_type##_begin);                                                         					\
+  TS_MARKER(Exec##node_type##_begin);                                                                           \
                                                                                                                 \
-  result = _Exec##node_type(pstate);                                                                            \
+  result = WrappedExec##node_type(pstate);                                                                      \
                                                                                                                 \
-  TS_MARKER(Exec##node_type##_end);                                                           					\
+  TS_MARKER(Exec##node_type##_end);                                                                             \
   TS_MARKER(                                                                                                    \
-    Exec##node_type##_features,                                                               					\
+    Exec##node_type##_features,                                                                                 \
     pstate->state->es_plannedstmt->queryId,                                                                     \
     castNode(node_type##State, pstate),                                                                         \
     pstate->plan                                                                                                \

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "tscout/marker.h"
+
+#define TS_EXECUTOR_WRAPPER(node_type)                                                                          \
+static TupleTableSlot *                                                                                         \
+Exec##node_type(PlanState *pstate)                                                                              \
+{                                                                                                               \
+  TupleTableSlot *result;                                                                                       \
+  TS_MARKER(Exec##node_type##_begin);                                                         					\
+                                                                                                                \
+  result = _Exec##node_type(pstate);                                                                            \
+                                                                                                                \
+  TS_MARKER(Exec##node_type##_end);                                                           					\
+  TS_MARKER(                                                                                                    \
+    Exec##node_type##_features,                                                               					\
+    pstate->state->es_plannedstmt->queryId,                                                                     \
+    castNode(node_type##State, pstate),                                                                         \
+    pstate->plan                                                                                                \
+  );                                                                                                            \
+  return result;                                                                                                \
+}

--- a/src/include/tscout/marker.h
+++ b/src/include/tscout/marker.h
@@ -3,8 +3,6 @@
 #include "c.h"
 #include "tscout/StaticTracepoint-ELFx86.h"
 
-// TODO(Matt): look at macros to automatically grab function name and file name
-
 // Define a Marker without a semaphore
 #define TS_MARKER(name, ...) \
 	FOLLY_SDT_PROBE_N(noisepage, name, 0, FOLLY_SDT_NARG(0, ##__VA_ARGS__), ##__VA_ARGS__)
@@ -21,22 +19,3 @@
 
 // Test if previously-definied semaphore is in use
 #define TS_MARKER_IS_ENABLED(name) (FOLLY_SDT_SEMAPHORE(noisepage, name) > 0)
-
-// Define variables required by all of the markers. This avoids the C90 warnings.
-#define TS_MARKER_SETUP()                                                                       \
-  /* Features. */                                                                               \
-  uint64_t query_id;                                                                            \
-  /* The current node. */                                                                       \
-  void *cur_node;
-
-// Define common features.
-#define TS_FEATURES_MARKER(name, current_node, plan_state_ptr, ...)                             \
-  query_id = plan_state_ptr->state->es_plannedstmt->queryId;                                    \
-  cur_node = (void *) current_node;                                                             \
-  TS_MARKER(                                                                                    \
-    name,                                                                                       \
-    query_id,                                                                                   \
-    cur_node,                                                                                   \
-    plan_state_ptr->plan,                                                                       \
-    ##__VA_ARGS__                                                                               \
-  );


### PR DESCRIPTION
This handles some minor refactors I saw while reviewing #11.

Changes:
- Simplified naming of markers. Instead of `filename_function_<blah>` it's now just `function_<blah>` which still seems unique enough. For example `nodeCtescan_ExecCteScan_begin` is now `ExecCteScan_begin`. This simplifies the .csv output file names too.
- New `TS_EXECUTOR_WRAPPER` macro in src/include/tscout/executors.h to reduce copy-paste code in executors.
- Wrapped executors are now `WrappedExec<blah>` instead of `_Exec<blah>` since underscore followed by uppercase is reserved by the compiler.