### PR TITLE
Fix exception with struct.pack for float/double features

### DIFF
--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -66,13 +66,12 @@ class BPFVariable:
         val : str
             The serialized value of this variable.
         """
-        val = str(getattr(output_event, self.name))
         if self.c_type == clang.cindex.TypeKind.FLOAT:
-            return str(struct.unpack('f', int(val).to_bytes(4, byteorder=sys.byteorder))[0])
+            return str(struct.unpack('f', getattr(output_event, self.name).to_bytes(4, byteorder=sys.byteorder))[0])
         elif self.c_type == clang.cindex.TypeKind.DOUBLE:
-            return str(struct.unpack('d', int(val).to_bytes(8, byteorder=sys.byteorder))[0])
+            return str(struct.unpack('d', getattr(output_event, self.name).to_bytes(8, byteorder=sys.byteorder))[0])
         else:
-            return val
+            return str(getattr(output_event, self.name))
 
 
 @dataclass

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -6,6 +6,7 @@ Define the Operating Units (OUs) and metrics to be collected.
 """
 
 import struct
+import sys
 from dataclasses import dataclass
 from enum import Enum, unique
 from typing import List, Mapping, Tuple
@@ -67,9 +68,9 @@ class BPFVariable:
         """
         val = str(getattr(output_event, self.name))
         if self.c_type == clang.cindex.TypeKind.FLOAT:
-            return str(struct.unpack('f', struct.pack('l', int(val)))[0])
+            return str(struct.unpack('f', int(val).to_bytes(4, byteorder=sys.byteorder))[0])
         elif self.c_type == clang.cindex.TypeKind.DOUBLE:
-            return str(struct.unpack('d', struct.pack('q', int(val)))[0])
+            return str(struct.unpack('d', int(val).to_bytes(8, byteorder=sys.byteorder))[0])
         else:
             return val
 


### PR DESCRIPTION
We were seeing an exception with `struct.pack` for some integer values when loading TPCC, which is odd because it was trying to pack into a quadword. Regardless, Python 3.2 added `int.to_bytes` so we'll just use that instead. Tested on dev9, and the cost values coming out still look correct.

It's possible we can elide this process entirely using ctypes magic on the underlying pointer, but that requires more work than we have time for right now.