### PR TITLE
Fix for recursive OUs

### DIFF
--- a/cmudb/tscout/collector.c
+++ b/cmudb/tscout/collector.c
@@ -17,5 +17,8 @@ BPF_PERF_ARRAY(cache_references, MAX_CPUS);
 BPF_PERF_ARRAY(cache_misses, MAX_CPUS);
 BPF_PERF_ARRAY(ref_cpu_cycles, MAX_CPUS);
 
-// Each OU gets its own ou_id->metrics for incomplete data
-BPF_HASH(incomplete_metrics, u32, struct resource_metrics);
+// Each OU gets its own ou_id->metrics for incomplete data.
+BPF_HASH(incomplete_metrics, u64, struct resource_metrics);
+
+// We expect `plan_node_id` to be unique within the call stack, even if OUs are recursive.
+static u64 incomplete_metrics_key(const u32 ou, const s32 plan_node_id) { return ((u64)ou) << 32 | plan_node_id; }

--- a/cmudb/tscout/collector.c
+++ b/cmudb/tscout/collector.c
@@ -17,7 +17,7 @@ BPF_PERF_ARRAY(cache_references, MAX_CPUS);
 BPF_PERF_ARRAY(cache_misses, MAX_CPUS);
 BPF_PERF_ARRAY(ref_cpu_cycles, MAX_CPUS);
 
-// Each OU gets its own ou_id->metrics for incomplete data.
+// Each OU gets its own ou_id,plan_node_id->metrics for incomplete data.
 BPF_HASH(incomplete_metrics, u64, struct resource_metrics);
 
 // We expect `plan_node_id` to be unique within the call stack, even if OUs are recursive.

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -27,20 +27,18 @@ void SUBST_OU_begin(struct pt_regs *ctx) {
   metrics.start_time = (bpf_ktime_get_ns() >> 10);
 
   // Store the start metrics in the subsystem map, waiting for end
-  u32 ou_k = SUBST_INDEX;
   s32 plan_node_id;
   bpf_usdt_readarg(1, ctx, &plan_node_id);
-  u64 key = incomplete_metrics_key(ou_k, plan_node_id);
+  u64 key = incomplete_metrics_key(SUBST_INDEX, plan_node_id);
   incomplete_metrics.update(&key, &metrics);
 }
 
 void SUBST_OU_end(struct pt_regs *ctx) {
   // Retrieve start metrics
   struct resource_metrics *metrics = NULL;
-  u32 ou_k = SUBST_INDEX;
   s32 plan_node_id;
   bpf_usdt_readarg(1, ctx, &plan_node_id);
-  u64 key = incomplete_metrics_key(ou_k, plan_node_id);
+  u64 key = incomplete_metrics_key(SUBST_INDEX, plan_node_id);
   metrics = incomplete_metrics.lookup(&key);
   if (metrics == NULL) {
     return;
@@ -83,10 +81,9 @@ BPF_PERF_OUTPUT(collector_results_SUBST_INDEX);
 void SUBST_OU_features(struct pt_regs *ctx) {
   // Retrieve completed metrics
   struct resource_metrics *metrics = NULL;
-  u32 ou_k = SUBST_INDEX;
   s32 plan_node_id;
   bpf_usdt_readarg(1, ctx, &plan_node_id);
-  u64 key = incomplete_metrics_key(ou_k, plan_node_id);
+  u64 key = incomplete_metrics_key(SUBST_INDEX, plan_node_id);
   metrics = incomplete_metrics.lookup(&key);
   if (metrics == NULL || metrics->end_time == 0) {
     // Arrived at the FEATURES marker out of order.

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -28,21 +28,27 @@ void SUBST_OU_begin(struct pt_regs *ctx) {
 
   // Store the start metrics in the subsystem map, waiting for end
   u32 ou_k = SUBST_INDEX;
-  incomplete_metrics.update(&ou_k, &metrics);
+  s32 plan_node_id;
+  bpf_usdt_readarg(1, ctx, &plan_node_id);
+  u64 key = incomplete_metrics_key(ou_k, plan_node_id);
+  incomplete_metrics.update(&key, &metrics);
 }
 
 void SUBST_OU_end(struct pt_regs *ctx) {
   // Retrieve start metrics
   struct resource_metrics *metrics = NULL;
   u32 ou_k = SUBST_INDEX;
-  metrics = incomplete_metrics.lookup(&ou_k);
+  s32 plan_node_id;
+  bpf_usdt_readarg(1, ctx, &plan_node_id);
+  u64 key = incomplete_metrics_key(ou_k, plan_node_id);
+  metrics = incomplete_metrics.lookup(&key);
   if (metrics == NULL) {
     return;
   }
 
   if (metrics->end_time != 0) {
     // Arrived at the END marker out of order.
-    incomplete_metrics.delete(&ou_k);
+    incomplete_metrics.delete(&key);
     return;
   }
 
@@ -52,7 +58,7 @@ void SUBST_OU_end(struct pt_regs *ctx) {
 
   // Probe for CPU counters
   if (!cpu_end(metrics)) {
-    incomplete_metrics.delete(&ou_k);
+    incomplete_metrics.delete(&key);
     return;
   }
   struct task_struct *p = (struct task_struct *)bpf_get_current_task();
@@ -62,7 +68,7 @@ void SUBST_OU_end(struct pt_regs *ctx) {
 #endif
 
   // Store the completed metrics in the subsystem map, waiting for features
-  incomplete_metrics.update(&ou_k, metrics);
+  incomplete_metrics.update(&key, metrics);
 }
 
 // A BPF array is defined because the OU output struct is typically larger
@@ -78,7 +84,10 @@ void SUBST_OU_features(struct pt_regs *ctx) {
   // Retrieve completed metrics
   struct resource_metrics *metrics = NULL;
   u32 ou_k = SUBST_INDEX;
-  metrics = incomplete_metrics.lookup(&ou_k);
+  s32 plan_node_id;
+  bpf_usdt_readarg(1, ctx, &plan_node_id);
+  u64 key = incomplete_metrics_key(ou_k, plan_node_id);
+  metrics = incomplete_metrics.lookup(&key);
   if (metrics == NULL || metrics->end_time == 0) {
     // Arrived at the FEATURES marker out of order.
     return;
@@ -102,7 +111,7 @@ void SUBST_OU_features(struct pt_regs *ctx) {
   SUBST_READARGS
 
   // This enforces the state machine of begin -> end -> features.
-  incomplete_metrics.delete(&ou_k);
+  incomplete_metrics.delete(&key);
   // The SUBST_OU_output_arr does not need to be deleted because it is memset to 0 every time.
 
   // Send output struct to userspace via subsystem's perf ring buffer

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -579,17 +579,14 @@ WrappedExecHashJoinImpl(PlanState *pstate, bool parallel)
 static pg_attribute_always_inline TupleTableSlot *
 ExecHashJoinImpl(PlanState *pstate, bool parallel) {
   TupleTableSlot *result;
-  TS_MARKER(ExecHashJoinImpl_begin);
+  TS_MARKER(ExecHashJoinImpl_begin, pstate->plan->plan_node_id);
 
   result = WrappedExecHashJoinImpl(pstate, parallel);
 
-  TS_MARKER(ExecHashJoinImpl_end);
-  TS_MARKER(
-	ExecHashJoinImpl_features,
-    pstate->state->es_plannedstmt->queryId,
-    castNode(HashJoinState, pstate),
-    pstate->plan
-  );
+  TS_MARKER(ExecHashJoinImpl_end, pstate->plan->plan_node_id);
+  TS_MARKER(ExecHashJoinImpl_features, pstate->plan->plan_node_id,
+            pstate->state->es_plannedstmt->queryId,
+            castNode(HashJoinState, pstate), pstate->plan);
 
   return result;
 }

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -96,26 +96,22 @@ WrappedExecSubPlan(SubPlanState *node,
 }
 
 /*
- * The result type here is Datum instead of TupleTableSlot * like most executors, so we can't use the macro in
- * tscout/executors.h and instead just reproduce the behavior. If tscout/executors.h changes, change this too.
+ * The result type here is Datum instead of TupleTableSlot * like most
+ * executors, so we can't use the macro in tscout/executors.h and instead just
+ * reproduce the behavior. If tscout/executors.h changes, change this too.
  */
-Datum
-ExecSubPlan(SubPlanState *node,
-			ExprContext *econtext,
-			bool *isNull)
-{
+Datum pg_attribute_always_inline ExecSubPlan(SubPlanState *node,
+                                             ExprContext *econtext,
+                                             bool *isNull) {
   Datum result;
-  TS_MARKER(ExecSubPlan_begin);
+  TS_MARKER(ExecSubPlan_begin, node->planstate->plan->plan_node_id);
 
   result = WrappedExecSubPlan(node, econtext, isNull);
 
-  TS_MARKER(ExecSubPlan_end);
-  TS_MARKER(
-	ExecSubPlan_features,
-	node->planstate->state->es_plannedstmt->queryId,
-    castNode(SubPlanState, node),
-	node->planstate->plan
-  );
+  TS_MARKER(ExecSubPlan_end, node->planstate->plan->plan_node_id);
+  TS_MARKER(ExecSubPlan_features, node->planstate->plan->plan_node_id,
+            node->planstate->state->es_plannedstmt->queryId,
+            castNode(SubPlanState, node), node->planstate->plan);
 
   return result;
 }

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -3,28 +3,27 @@
 #include "tscout/marker.h"
 
 /*
- * Wrapper to add TScout markers to an executor. In the executor file, rename the current Exec<blah> function to
- * WrappedExec<blah> and then add TS_EXECUTOR_WRAPPER<blah> beneath it. See src/backend/executors for examples.
+ * Wrapper to add TScout markers to an executor. In the executor file, rename
+ * the current Exec<blah> function to WrappedExec<blah> and then add
+ * TS_EXECUTOR_WRAPPER<blah> beneath it. See src/backend/executors for examples.
  *
- * There is a small list of executors that cannot use this macro due to function signature differences. If the macro
- * below changes, be sure to update those executors as well. The current list is:
+ * There is a small list of executors that cannot use this macro due to function
+ * signature differences. If the macro below changes, be sure to update those
+ * executors as well. The current list is:
+ *
  * src/backend/executors/nodeSubplan.c
+ * src/backend/executors/nodeHashJoin.c
  */
-#define TS_EXECUTOR_WRAPPER(node_type)                                                                          \
-static TupleTableSlot *                                                                                         \
-Exec##node_type(PlanState *pstate)                                                                              \
-{                                                                                                               \
-  TupleTableSlot *result;                                                                                       \
-  TS_MARKER(Exec##node_type##_begin);                                                                           \
-                                                                                                                \
-  result = WrappedExec##node_type(pstate);                                                                      \
-                                                                                                                \
-  TS_MARKER(Exec##node_type##_end);                                                                             \
-  TS_MARKER(                                                                                                    \
-    Exec##node_type##_features,                                                                                 \
-    pstate->state->es_plannedstmt->queryId,                                                                     \
-    castNode(node_type##State, pstate),                                                                         \
-    pstate->plan                                                                                                \
-  );                                                                                                            \
-  return result;                                                                                                \
-}
+#define TS_EXECUTOR_WRAPPER(node_type)                                         \
+  static TupleTableSlot *Exec##node_type(PlanState *pstate) {                  \
+    TupleTableSlot *result;                                                    \
+    TS_MARKER(Exec##node_type##_begin, pstate->plan->plan_node_id);            \
+                                                                               \
+    result = WrappedExec##node_type(pstate);                                   \
+                                                                               \
+    TS_MARKER(Exec##node_type##_end, pstate->plan->plan_node_id);              \
+    TS_MARKER(Exec##node_type##_features, pstate->plan->plan_node_id,          \
+              pstate->state->es_plannedstmt->queryId,                          \
+              castNode(node_type##State, pstate), pstate->plan);               \
+    return result;                                                             \
+  }


### PR DESCRIPTION
### Background
Recursive OUs don't work in the main branch because the key we use to store incomplete metrics snapshots is just the OU index. For example, when joining three tables you get this plan:

```sql
test=# explain SELECT * FROM foo1 LEFT JOIN foo2 ON foo1.id = foo2.id LEFT JOIN foo3 ON foo2.id = foo3.id;
                                   QUERY PLAN                                    
---------------------------------------------------------------------------------
 Merge Left Join  (cost=389.22..2948.35 rows=146380 width=56)
   Merge Cond: (foo1.id = foo2.id)
   ->  Sort  (cost=88.17..91.35 rows=1270 width=36)
         Sort Key: foo1.id
         ->  Seq Scan on foo1  (cost=0.00..22.70 rows=1270 width=36)
   ->  Materialize  (cost=301.05..715.76 rows=23052 width=20)
         ->  Merge Left Join  (cost=301.05..658.13 rows=23052 width=20)
               Merge Cond: (foo2.id = foo3.id)
               ->  Sort  (cost=158.51..164.16 rows=2260 width=8)
                     Sort Key: foo2.id
                     ->  Seq Scan on foo2  (cost=0.00..32.60 rows=2260 width=8)
               ->  Sort  (cost=142.54..147.64 rows=2040 width=12)
                     Sort Key: foo3.id
                     ->  Seq Scan on foo3  (cost=0.00..30.40 rows=2040 width=12)
(14 rows)

test=# 
```

All 3 tables have 3 tuples each with matching join predicates. The output of [ExecMergeJoin_pg14.csv](https://github.com/cmu-db/postgres/files/7507605/ExecMergeJoin_pg14.csv) has four data points: 3 for the tuples, 1 when it's done. The problem is that we're only getting results from the child MergeJoin operator. Note that plan_node_id is 4 for all of the data points. When the BEGIN marker is hit in the child, it resets the metrics that were started for the parent because they have the same OU index.

### Changes
- Change key on incomplete metrics map from `u32 ou_k` to `u64 ou_k | plan_node_id`
- Add `plan_node_id` as a USDT arg
- Formatting cleanup

These changes assume `plan_node_id` is unique in the call stack, which seems reasonable due to:
```
int			plan_node_id;	/* unique across entire final plan tree */
```

### Result
[ExecMergeJoin_fix.csv](https://github.com/cmu-db/postgres/files/7507626/ExecMergeJoin_fix.csv) now has the correct number of data points. Note that child operators are listed first because they complete first, and you can see the following parent data point with begin and end timestamps that are before and after the child, respectively. We also see plan_node_ids of 0 and 4 now, showing the parent and child operators.

### Alternative
We could use BPF_STACK but the BCC version included with 20.04 by default is too old. I don't want to bump our toolchain, so this is the solution for now. We can revisit which approach makes more sense with 22.04.