### PR TITLE
Accumulate BEGIN/END markers, flush at FEATURES

### DIFF
--- a/cmudb/tscout/collector.c
+++ b/cmudb/tscout/collector.c
@@ -17,9 +17,10 @@ BPF_PERF_ARRAY(cache_references, MAX_CPUS);
 BPF_PERF_ARRAY(cache_misses, MAX_CPUS);
 BPF_PERF_ARRAY(ref_cpu_cycles, MAX_CPUS);
 
-// Each OU gets its own ou_id,plan_node_id->metrics for incomplete data.
+// Stores accumulated metrics, waiting to hit a FEATURES Marker
 BPF_HASH(complete_metrics, u64, struct resource_metrics, 32);  // TODO(Matt: Think about this size more
-BPF_HASH(running_metrics, u64, struct resource_metrics, 32);   // TODO(Matt: Think about this size more
+// Stores a snapshot of the metrics at START Marker, waiting to hit an END Marker
+BPF_HASH(running_metrics, u64, struct resource_metrics, 32);  // TODO(Matt: Think about this size more
 
 // We expect `plan_node_id` to be unique within the call stack, even if OUs are recursive.
 static u64 ou_key(const u32 ou, const s32 ou_instance) { return ((u64)ou) << 32 | ou_instance; }

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -1,12 +1,12 @@
 // SUBST_OU is replaced by the subsystem's name
 struct SUBST_OU_features {
-  SUBST_FEATURES  // Replaced by a list of the features for this subsystem
+  SUBST_FEATURES;  // Replaced by a list of the features for this subsystem
 };
 
 struct SUBST_OU_output {
   u32 ou_index;
-  SUBST_FEATURES  // Replaced by a list of the features for this subsystem
-      METRICS     // Replaced by the list of metrics
+  SUBST_FEATURES;  // Replaced by a list of the features for this subsystem
+  SUBST_METRICS;   // Replaced by the list of metrics
 };
 
 void SUBST_OU_begin(struct pt_regs *ctx) {
@@ -29,8 +29,8 @@ void SUBST_OU_begin(struct pt_regs *ctx) {
   // Store the start metrics in the subsystem map, waiting for end
   s32 plan_node_id;
   bpf_usdt_readarg(1, ctx, &plan_node_id);
-  u64 key = incomplete_metrics_key(SUBST_INDEX, plan_node_id);
-  incomplete_metrics.update(&key, &metrics);
+  u64 key = ou_key(SUBST_INDEX, plan_node_id);
+  running_metrics.update(&key, &metrics);
 }
 
 void SUBST_OU_end(struct pt_regs *ctx) {
@@ -38,15 +38,15 @@ void SUBST_OU_end(struct pt_regs *ctx) {
   struct resource_metrics *metrics = NULL;
   s32 plan_node_id;
   bpf_usdt_readarg(1, ctx, &plan_node_id);
-  u64 key = incomplete_metrics_key(SUBST_INDEX, plan_node_id);
-  metrics = incomplete_metrics.lookup(&key);
+  u64 key = ou_key(SUBST_INDEX, plan_node_id);
+  metrics = running_metrics.lookup(&key);
   if (metrics == NULL) {
     return;
   }
 
   if (metrics->end_time != 0) {
     // Arrived at the END marker out of order.
-    incomplete_metrics.delete(&key);
+    running_metrics.delete(&key);
     return;
   }
 
@@ -56,7 +56,7 @@ void SUBST_OU_end(struct pt_regs *ctx) {
 
   // Probe for CPU counters
   if (!cpu_end(metrics)) {
-    incomplete_metrics.delete(&key);
+    running_metrics.delete(&key);
     return;
   }
   struct task_struct *p = (struct task_struct *)bpf_get_current_task();
@@ -66,7 +66,19 @@ void SUBST_OU_end(struct pt_regs *ctx) {
 #endif
 
   // Store the completed metrics in the subsystem map, waiting for features
-  incomplete_metrics.update(&key, metrics);
+  struct resource_metrics *accumulated_metrics = NULL;
+  accumulated_metrics = complete_metrics.lookup(&key);
+  if (accumulated_metrics == NULL) {
+    // They don't exist yet, but that's okay, this could be the first tuple. Just drop in the this END instance's
+    // metrics as the complete ones.
+    complete_metrics.update(&key, metrics);
+  } else {
+    // We have accumulated metrics already. Let's add them.
+    metrics_accumulate(accumulated_metrics, metrics);
+  }
+
+  running_metrics.delete(&key);
+  //  complete_metrics.update(&key, metrics); //TODO(Matt): shouldn't be necessary
 }
 
 // A BPF array is defined because the OU output struct is typically larger
@@ -83,8 +95,8 @@ void SUBST_OU_features(struct pt_regs *ctx) {
   struct resource_metrics *metrics = NULL;
   s32 plan_node_id;
   bpf_usdt_readarg(1, ctx, &plan_node_id);
-  u64 key = incomplete_metrics_key(SUBST_INDEX, plan_node_id);
-  metrics = incomplete_metrics.lookup(&key);
+  u64 key = ou_key(SUBST_INDEX, plan_node_id);
+  metrics = complete_metrics.lookup(&key);
   if (metrics == NULL || metrics->end_time == 0) {
     // Arrived at the FEATURES marker out of order.
     return;
@@ -108,7 +120,7 @@ void SUBST_OU_features(struct pt_regs *ctx) {
   SUBST_READARGS
 
   // This enforces the state machine of begin -> end -> features.
-  incomplete_metrics.delete(&key);
+  complete_metrics.delete(&key);
   // The SUBST_OU_output_arr does not need to be deleted because it is memset to 0 every time.
 
   // Send output struct to userspace via subsystem's perf ring buffer

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -69,7 +69,7 @@ void SUBST_OU_end(struct pt_regs *ctx) {
   struct resource_metrics *accumulated_metrics = NULL;
   accumulated_metrics = complete_metrics.lookup(&key);
   if (accumulated_metrics == NULL) {
-    // They don't exist yet, but that's okay, this could be the first tuple. Just drop in the this END instance's
+    // They don't exist yet, but that's okay, this could be the first tuple. Just drop in the END instance's
     // metrics as the complete ones.
     complete_metrics.update(&key, metrics);
   } else {
@@ -78,7 +78,6 @@ void SUBST_OU_end(struct pt_regs *ctx) {
   }
 
   running_metrics.delete(&key);
-  //  complete_metrics.update(&key, metrics); //TODO(Matt): shouldn't be necessary
 }
 
 // A BPF array is defined because the OU output struct is typically larger

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -106,222 +106,222 @@ feature_types : List[Feature]
     If you modify this list, you must change the markers in PostgreSQL source.
 """
 OU_DEFS = [
-    # ("ExecAgg",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("AggState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecAppend",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("AppendState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecCteScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("CteScanState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecCustomScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("CustomScanState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecForeignScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ForeignScanState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecFunctionScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("FunctionScanState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecGather",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("GatherState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecGatherMerge",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("GatherMergeState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecGroup",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("GroupState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecHashJoinImpl",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("HashJoinState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecIncrementalSort",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("IncrementalSortState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecIndexOnlyScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("IndexOnlyScanState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecIndexScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("IndexScanState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecLimit",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("LimitState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecLockRows",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("LockRowsState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecMaterial",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("MaterialState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecMergeAppend",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("MergeAppendState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecMergeJoin",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("MergeJoinState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecModifyTable",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ModifyTableState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecNamedTuplestoreScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("NamedTuplestoreScanState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecNestLoop",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("NestLoopState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecProjectSet",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ProjectSetState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecRecursiveUnion",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("RecursiveUnionState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecResult",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ResultState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecSampleScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("SampleScanState"),
-    #      Feature("Plan")
-    #  ]),
+    ("ExecAgg",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("AggState"),
+         Feature("Plan")
+     ]),
+    ("ExecAppend",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("AppendState"),
+         Feature("Plan")
+     ]),
+    ("ExecCteScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("CteScanState"),
+         Feature("Plan")
+     ]),
+    ("ExecCustomScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("CustomScanState"),
+         Feature("Plan")
+     ]),
+    ("ExecForeignScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ForeignScanState"),
+         Feature("Plan")
+     ]),
+    ("ExecFunctionScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("FunctionScanState"),
+         Feature("Plan")
+     ]),
+    ("ExecGather",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("GatherState"),
+         Feature("Plan")
+     ]),
+    ("ExecGatherMerge",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("GatherMergeState"),
+         Feature("Plan")
+     ]),
+    ("ExecGroup",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("GroupState"),
+         Feature("Plan")
+     ]),
+    ("ExecHashJoinImpl",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("HashJoinState"),
+         Feature("Plan")
+     ]),
+    ("ExecIncrementalSort",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("IncrementalSortState"),
+         Feature("Plan")
+     ]),
+    ("ExecIndexOnlyScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("IndexOnlyScanState"),
+         Feature("Plan")
+     ]),
+    ("ExecIndexScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("IndexScanState"),
+         Feature("Plan")
+     ]),
+    ("ExecLimit",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("LimitState"),
+         Feature("Plan")
+     ]),
+    ("ExecLockRows",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("LockRowsState"),
+         Feature("Plan")
+     ]),
+    ("ExecMaterial",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("MaterialState"),
+         Feature("Plan")
+     ]),
+    ("ExecMergeAppend",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("MergeAppendState"),
+         Feature("Plan")
+     ]),
+    ("ExecMergeJoin",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("MergeJoinState"),
+         Feature("Plan")
+     ]),
+    ("ExecModifyTable",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ModifyTableState"),
+         Feature("Plan")
+     ]),
+    ("ExecNamedTuplestoreScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("NamedTuplestoreScanState"),
+         Feature("Plan")
+     ]),
+    ("ExecNestLoop",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("NestLoopState"),
+         Feature("Plan")
+     ]),
+    ("ExecProjectSet",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ProjectSetState"),
+         Feature("Plan")
+     ]),
+    ("ExecRecursiveUnion",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("RecursiveUnionState"),
+         Feature("Plan")
+     ]),
+    ("ExecResult",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ResultState"),
+         Feature("Plan")
+     ]),
+    ("ExecSampleScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("SampleScanState"),
+         Feature("Plan")
+     ]),
     ("ExecSeqScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("SeqScanState"),
          Feature("Plan")
      ]),
-    # ("ExecSetOp",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("SetOpState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecSort",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("SortState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecSubPlan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("SubPlan"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecSubqueryScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("SubqueryScanState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecTableFuncScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("TableFuncScanState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecTidScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("TidScanState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecUnique",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("UniqueState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecValuesScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ValuesScanState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecWindowAgg",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("WindowAggState"),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecWorkTableScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("WorkTableScanState"),
-    #      Feature("Plan")
-    #  ]),
+    ("ExecSetOp",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("SetOpState"),
+         Feature("Plan")
+     ]),
+    ("ExecSort",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("SortState"),
+         Feature("Plan")
+     ]),
+    ("ExecSubPlan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("SubPlan"),
+         Feature("Plan")
+     ]),
+    ("ExecSubqueryScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("SubqueryScanState"),
+         Feature("Plan")
+     ]),
+    ("ExecTableFuncScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("TableFuncScanState"),
+         Feature("Plan")
+     ]),
+    ("ExecTidScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("TidScanState"),
+         Feature("Plan")
+     ]),
+    ("ExecUnique",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("UniqueState"),
+         Feature("Plan")
+     ]),
+    ("ExecValuesScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ValuesScanState"),
+         Feature("Plan")
+     ]),
+    ("ExecWindowAgg",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("WindowAggState"),
+         Feature("Plan")
+     ]),
+    ("ExecWorkTableScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("WorkTableScanState"),
+         Feature("Plan")
+     ]),
 ]
 
 # The metrics to be defined for every OU.

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -106,222 +106,222 @@ feature_types : List[Feature]
     If you modify this list, you must change the markers in PostgreSQL source.
 """
 OU_DEFS = [
-    ("ExecAgg",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("AggState"),
-         Feature("Plan")
-     ]),
-    ("ExecAppend",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("AppendState"),
-         Feature("Plan")
-     ]),
-    ("ExecCteScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("CteScanState"),
-         Feature("Plan")
-     ]),
-    ("ExecCustomScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("CustomScanState"),
-         Feature("Plan")
-     ]),
-    ("ExecForeignScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ForeignScanState"),
-         Feature("Plan")
-     ]),
-    ("ExecFunctionScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("FunctionScanState"),
-         Feature("Plan")
-     ]),
-    ("ExecGather",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("GatherState"),
-         Feature("Plan")
-     ]),
-    ("ExecGatherMerge",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("GatherMergeState"),
-         Feature("Plan")
-     ]),
-    ("ExecGroup",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("GroupState"),
-         Feature("Plan")
-     ]),
-    ("ExecHashJoinImpl",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("HashJoinState"),
-         Feature("Plan")
-     ]),
-    ("ExecIncrementalSort",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IncrementalSortState"),
-         Feature("Plan")
-     ]),
-    ("ExecIndexOnlyScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IndexOnlyScanState"),
-         Feature("Plan")
-     ]),
-    ("ExecIndexScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IndexScanState"),
-         Feature("Plan")
-     ]),
-    ("ExecLimit",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("LimitState"),
-         Feature("Plan")
-     ]),
-    ("ExecLockRows",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("LockRowsState"),
-         Feature("Plan")
-     ]),
-    ("ExecMaterial",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MaterialState"),
-         Feature("Plan")
-     ]),
-    ("ExecMergeAppend",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MergeAppendState"),
-         Feature("Plan")
-     ]),
-    ("ExecMergeJoin",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MergeJoinState"),
-         Feature("Plan")
-     ]),
-    ("ExecModifyTable",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ModifyTableState"),
-         Feature("Plan")
-     ]),
-    ("ExecNamedTuplestoreScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("NamedTuplestoreScanState"),
-         Feature("Plan")
-     ]),
-    ("ExecNestLoop",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("NestLoopState"),
-         Feature("Plan")
-     ]),
-    ("ExecProjectSet",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ProjectSetState"),
-         Feature("Plan")
-     ]),
-    ("ExecRecursiveUnion",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("RecursiveUnionState"),
-         Feature("Plan")
-     ]),
-    ("ExecResult",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ResultState"),
-         Feature("Plan")
-     ]),
-    ("ExecSampleScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SampleScanState"),
-         Feature("Plan")
-     ]),
+    # ("ExecAgg",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("AggState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecAppend",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("AppendState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecCteScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("CteScanState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecCustomScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("CustomScanState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecForeignScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ForeignScanState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecFunctionScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("FunctionScanState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecGather",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("GatherState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecGatherMerge",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("GatherMergeState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecGroup",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("GroupState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecHashJoinImpl",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("HashJoinState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecIncrementalSort",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("IncrementalSortState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecIndexOnlyScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("IndexOnlyScanState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecIndexScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("IndexScanState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecLimit",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("LimitState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecLockRows",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("LockRowsState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecMaterial",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("MaterialState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecMergeAppend",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("MergeAppendState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecMergeJoin",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("MergeJoinState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecModifyTable",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ModifyTableState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecNamedTuplestoreScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("NamedTuplestoreScanState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecNestLoop",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("NestLoopState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecProjectSet",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ProjectSetState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecRecursiveUnion",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("RecursiveUnionState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecResult",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ResultState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecSampleScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("SampleScanState"),
+    #      Feature("Plan")
+    #  ]),
     ("ExecSeqScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("SeqScanState"),
          Feature("Plan")
      ]),
-    ("ExecSetOp",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SetOpState"),
-         Feature("Plan")
-     ]),
-    ("ExecSort",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SortState"),
-         Feature("Plan")
-     ]),
-    ("ExecSubPlan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SubPlan"),
-         Feature("Plan")
-     ]),
-    ("ExecSubqueryScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SubqueryScanState"),
-         Feature("Plan")
-     ]),
-    ("ExecTableFuncScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("TableFuncScanState"),
-         Feature("Plan")
-     ]),
-    ("ExecTidScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("TidScanState"),
-         Feature("Plan")
-     ]),
-    ("ExecUnique",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("UniqueState"),
-         Feature("Plan")
-     ]),
-    ("ExecValuesScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ValuesScanState"),
-         Feature("Plan")
-     ]),
-    ("ExecWindowAgg",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("WindowAggState"),
-         Feature("Plan")
-     ]),
-    ("ExecWorkTableScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("WorkTableScanState"),
-         Feature("Plan")
-     ]),
+    # ("ExecSetOp",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("SetOpState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecSort",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("SortState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecSubPlan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("SubPlan"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecSubqueryScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("SubqueryScanState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecTableFuncScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("TableFuncScanState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecTidScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("TidScanState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecUnique",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("UniqueState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecValuesScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ValuesScanState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecWindowAgg",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("WindowAggState"),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecWorkTableScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("WorkTableScanState"),
+    #      Feature("Plan")
+    #  ]),
 ]
 
 # The metrics to be defined for every OU.

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -102,11 +102,9 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     defs = ['{} {}'.format(metric.bpf_type, metric.name) for metric in metrics]
     metrics_struct = ';\n'.join(defs) + ';'
     collector_c = collector_c.replace("SUBST_METRICS", metrics_struct)
-
     accumulate = ['lhs->{} += rhs->{}'.format(metric.name, metric.name) for metric in metrics if
                   metric.name not in ('start_time', 'end_time', 'cpu_id')]  # don't accumulate these 3 metrics
     metrics_accumulate = ';\n'.join(accumulate) + ';'
-    print(metrics_accumulate)
     collector_c = collector_c.replace("SUBST_ACCUMULATE", metrics_accumulate)
 
     num_cpus = len(utils.get_online_cpus())

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -101,7 +101,14 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     # Replace remaining placeholders in C code.
     defs = ['{} {}'.format(metric.bpf_type, metric.name) for metric in metrics]
     metrics_struct = ';\n'.join(defs) + ';'
-    collector_c = collector_c.replace("METRICS", metrics_struct)
+    collector_c = collector_c.replace("SUBST_METRICS", metrics_struct)
+
+    accumulate = ['lhs->{} += rhs->{}'.format(metric.name, metric.name) for metric in metrics if
+                  metric.name not in ('start_time', 'end_time', 'cpu_id')]  # don't accumulate these 3 metrics
+    metrics_accumulate = ';\n'.join(accumulate) + ';'
+    print(metrics_accumulate)
+    collector_c = collector_c.replace("SUBST_ACCUMULATE", metrics_accumulate)
+
     num_cpus = len(utils.get_online_cpus())
     collector_c = collector_c.replace("MAX_CPUS", str(num_cpus))
 

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -4382,6 +4382,9 @@ ExecEndAgg(AggState *node)
 	int			numGroupingSets = Max(node->maxsets, 1);
 	int			setno;
 
+        TS_MARKER(ExecAgg_features, node->ss.ps.plan->plan_node_id,
+                  node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	/*
 	 * When ending a parallel worker, copy the statistics gathered by the
 	 * worker back into shared memory so that it can be picked up by the main

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -400,6 +400,9 @@ ExecEndAppend(AppendState *node)
 	int			nplans;
 	int			i;
 
+        TS_MARKER(ExecAppend_features, node->ps.plan->plan_node_id,
+            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+
 	/*
 	 * get information from the node
 	 */

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -289,6 +289,10 @@ ExecInitCteScan(CteScan *node, EState *estate, int eflags)
 void
 ExecEndCteScan(CteScanState *node)
 {
+
+        TS_MARKER(ExecCteScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	/*
 	 * Free exprcontext
 	 */

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -121,6 +121,10 @@ TS_EXECUTOR_WRAPPER(CustomScan)
 void
 ExecEndCustomScan(CustomScanState *node)
 {
+
+        TS_MARKER(ExecCustomScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	Assert(node->methods->EndCustomScan != NULL);
 	node->methods->EndCustomScan(node);
 

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -292,6 +292,9 @@ ExecEndForeignScan(ForeignScanState *node)
 	ForeignScan *plan = (ForeignScan *) node->ss.ps.plan;
 	EState	   *estate = node->ss.ps.state;
 
+        TS_MARKER(ExecForeignScan_features, node->ss.ps.plan->plan_node_id,
+                  node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	/* Let the FDW shut down */
 	if (plan->operation != CMD_SELECT)
 	{

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -526,6 +526,9 @@ ExecEndFunctionScan(FunctionScanState *node)
 {
 	int			i;
 
+        TS_MARKER(ExecFunctionScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	/*
 	 * Free the exprcontext
 	 */

--- a/src/backend/executor/nodeGather.c
+++ b/src/backend/executor/nodeGather.c
@@ -251,6 +251,8 @@ TS_EXECUTOR_WRAPPER(Gather)
 void
 ExecEndGather(GatherState *node)
 {
+        TS_MARKER(ExecGather_features, node->ps.plan->plan_node_id,
+            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
 	ExecEndNode(outerPlanState(node));	/* let children clean up first */
 	ExecShutdownGather(node);
 	ExecFreeExprContext(&node->ps);

--- a/src/backend/executor/nodeGatherMerge.c
+++ b/src/backend/executor/nodeGatherMerge.c
@@ -291,6 +291,8 @@ TS_EXECUTOR_WRAPPER(GatherMerge)
 void
 ExecEndGatherMerge(GatherMergeState *node)
 {
+        TS_MARKER(ExecGatherMerge_features, node->ps.plan->plan_node_id,
+            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
 	ExecEndNode(outerPlanState(node));	/* let children clean up first */
 	ExecShutdownGatherMerge(node);
 	ExecFreeExprContext(&node->ps);

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -231,6 +231,9 @@ ExecEndGroup(GroupState *node)
 {
 	PlanState  *outerPlan;
 
+        TS_MARKER(ExecGroup_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	ExecFreeExprContext(&node->ss.ps);
 
 	/* clean up tuple table */

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -778,7 +778,7 @@ void
 ExecEndHashJoin(HashJoinState *node)
 {
 
-  TS_MARKER(ExecHashJoinImpl_features, node->js.ps.plan->plan_node_id,
+        TS_MARKER(ExecHashJoinImpl_features, node->js.ps.plan->plan_node_id,
             node->js.ps.state->es_plannedstmt->queryId, node, node->js.ps.plan);
 
         /*

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -584,9 +584,6 @@ ExecHashJoinImpl(PlanState *pstate, bool parallel) {
   result = WrappedExecHashJoinImpl(pstate, parallel);
 
   TS_MARKER(ExecHashJoinImpl_end, pstate->plan->plan_node_id);
-  TS_MARKER(ExecHashJoinImpl_features, pstate->plan->plan_node_id,
-            pstate->state->es_plannedstmt->queryId,
-            castNode(HashJoinState, pstate), pstate->plan);
 
   return result;
 }
@@ -780,7 +777,11 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
 void
 ExecEndHashJoin(HashJoinState *node)
 {
-	/*
+
+  TS_MARKER(ExecHashJoinImpl_features, node->js.ps.plan->plan_node_id,
+            node->js.ps.state->es_plannedstmt->queryId, node, node->js.ps.plan);
+
+        /*
 	 * Free hash table
 	 */
 	if (node->hj_HashTable)

--- a/src/backend/executor/nodeIncrementalSort.c
+++ b/src/backend/executor/nodeIncrementalSort.c
@@ -1078,6 +1078,8 @@ ExecInitIncrementalSort(IncrementalSort *node, EState *estate, int eflags)
 void
 ExecEndIncrementalSort(IncrementalSortState *node)
 {
+        TS_MARKER(ExecIncrementalSort_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
 	SO_printf("ExecEndIncrementalSort: shutting down sort node\n");
 
 	/* clean out the scan tuple */

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -374,6 +374,9 @@ ExecEndIndexOnlyScan(IndexOnlyScanState *node)
 	Relation	indexRelationDesc;
 	IndexScanDesc indexScanDesc;
 
+        TS_MARKER(ExecIndexOnlyScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	/*
 	 * extract information from the node
 	 */

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -788,6 +788,9 @@ ExecEndIndexScan(IndexScanState *node)
 	Relation	indexRelationDesc;
 	IndexScanDesc indexScanDesc;
 
+        TS_MARKER(ExecIndexScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	/*
 	 * extract information from the node
 	 */

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -360,6 +360,9 @@ recompute_limits(LimitState *node)
 	Datum		val;
 	bool		isNull;
 
+        TS_MARKER(ExecLimit_features, node->ps.plan->plan_node_id,
+                  node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+
 	if (node->limitOffset)
 	{
 		val = ExecEvalExprSwitchContext(node->limitOffset,

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -388,6 +388,9 @@ ExecInitLockRows(LockRows *node, EState *estate, int eflags)
 void
 ExecEndLockRows(LockRowsState *node)
 {
+        TS_MARKER(ExecLockRows_features, node->ps.plan->plan_node_id,
+            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+
 	/* We may have shut down EPQ already, but no harm in another call */
 	EvalPlanQualEnd(&node->lr_epqstate);
 	ExecEndNode(outerPlanState(node));

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -242,6 +242,9 @@ ExecInitMaterial(Material *node, EState *estate, int eflags)
 void
 ExecEndMaterial(MaterialState *node)
 {
+        TS_MARKER(ExecMaterial_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	/*
 	 * clean out the tuple table
 	 */

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -338,6 +338,9 @@ ExecEndMergeAppend(MergeAppendState *node)
 	int			nplans;
 	int			i;
 
+        TS_MARKER(ExecMergeAppend_features, node->ps.plan->plan_node_id,
+                  node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+
 	/*
 	 * get information from the node
 	 */

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1634,6 +1634,9 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 void
 ExecEndMergeJoin(MergeJoinState *node)
 {
+        TS_MARKER(ExecMergeJoin_features, node->js.ps.plan->plan_node_id,
+            node->js.ps.state->es_plannedstmt->queryId, node, node->js.ps.plan);
+
 	MJ1_printf("ExecEndMergeJoin: %s\n",
 			   "ending node processing");
 

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -3173,6 +3173,9 @@ ExecEndModifyTable(ModifyTableState *node)
 {
 	int			i;
 
+        TS_MARKER(ExecModifyTable_features, node->ps.plan->plan_node_id,
+            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+
 	/*
 	 * Allow any FDWs to shut down
 	 */

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -166,6 +166,9 @@ ExecInitNamedTuplestoreScan(NamedTuplestoreScan *node, EState *estate, int eflag
 void
 ExecEndNamedTuplestoreScan(NamedTuplestoreScanState *node)
 {
+        TS_MARKER(ExecNamedTuplestoreScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	/*
 	 * Free exprcontext
 	 */

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -364,6 +364,9 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 void
 ExecEndNestLoop(NestLoopState *node)
 {
+        TS_MARKER(ExecNestLoop_features, node->js.ps.plan->plan_node_id,
+            node->js.ps.state->es_plannedstmt->queryId, node, node->js.ps.plan);
+
 	NL1_printf("ExecEndNestLoop: %s\n",
 			   "ending node processing");
 

--- a/src/backend/executor/nodeProjectSet.c
+++ b/src/backend/executor/nodeProjectSet.c
@@ -323,6 +323,9 @@ ExecInitProjectSet(ProjectSet *node, EState *estate, int eflags)
 void
 ExecEndProjectSet(ProjectSetState *node)
 {
+        TS_MARKER(ExecProjectSet_features, node->ps.plan->plan_node_id,
+            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+
 	/*
 	 * Free the exprcontext
 	 */

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -274,6 +274,9 @@ ExecInitRecursiveUnion(RecursiveUnion *node, EState *estate, int eflags)
 void
 ExecEndRecursiveUnion(RecursiveUnionState *node)
 {
+        TS_MARKER(ExecRecursiveUnion_features, node->ps.plan->plan_node_id,
+            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+
 	/* Release tuplestores */
 	tuplestore_end(node->working_table);
 	tuplestore_end(node->intermediate_table);

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -243,6 +243,9 @@ ExecInitResult(Result *node, EState *estate, int eflags)
 void
 ExecEndResult(ResultState *node)
 {
+        TS_MARKER(ExecResult_features, node->ps.plan->plan_node_id,
+            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+
 	/*
 	 * Free the exprcontext
 	 */

--- a/src/backend/executor/nodeSamplescan.c
+++ b/src/backend/executor/nodeSamplescan.c
@@ -184,6 +184,9 @@ ExecInitSampleScan(SampleScan *node, EState *estate, int eflags)
 void
 ExecEndSampleScan(SampleScanState *node)
 {
+        TS_MARKER(ExecSampleScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	/*
 	 * Tell sampling function that we finished the scan.
 	 */

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -115,15 +115,7 @@ WrappedExecSeqScan(PlanState *pstate)
 					(ExecScanRecheckMtd) SeqRecheck);
 }
 
-static TupleTableSlot *ExecSeqScan(PlanState *pstate) {
-  TupleTableSlot *result;
-  TS_MARKER(ExecSeqScan_begin, pstate->plan->plan_node_id);
-
-  result = WrappedExecSeqScan(pstate);
-
-  TS_MARKER(ExecSeqScan_end, pstate->plan->plan_node_id);
-  return result;
-}
+TS_EXECUTOR_WRAPPER(SeqScan)
 
 /* ----------------------------------------------------------------
  *		ExecInitSeqScan

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -115,7 +115,15 @@ WrappedExecSeqScan(PlanState *pstate)
 					(ExecScanRecheckMtd) SeqRecheck);
 }
 
-TS_EXECUTOR_WRAPPER(SeqScan)
+static TupleTableSlot *ExecSeqScan(PlanState *pstate) {
+  TupleTableSlot *result;
+  TS_MARKER(ExecSeqScan_begin, pstate->plan->plan_node_id);
+
+  result = WrappedExecSeqScan(pstate);
+
+  TS_MARKER(ExecSeqScan_end, pstate->plan->plan_node_id);
+  return result;
+}
 
 /* ----------------------------------------------------------------
  *		ExecInitSeqScan
@@ -186,6 +194,9 @@ void
 ExecEndSeqScan(SeqScanState *node)
 {
 	TableScanDesc scanDesc;
+
+        TS_MARKER(ExecSeqScan_features, node->ss.ps.plan->plan_node_id,
+                  node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
 
 	/*
 	 * get information from node

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -188,7 +188,7 @@ ExecEndSeqScan(SeqScanState *node)
 	TableScanDesc scanDesc;
 
         TS_MARKER(ExecSeqScan_features, node->ss.ps.plan->plan_node_id,
-                  node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
 
 	/*
 	 * get information from node

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -585,6 +585,9 @@ ExecInitSetOp(SetOp *node, EState *estate, int eflags)
 void
 ExecEndSetOp(SetOpState *node)
 {
+        TS_MARKER(ExecSetOp_features, node->ps.plan->plan_node_id,
+            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+
 	/* clean up tuple table */
 	ExecClearTuple(node->ps.ps_ResultTupleSlot);
 

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -237,6 +237,9 @@ ExecInitSort(Sort *node, EState *estate, int eflags)
 void
 ExecEndSort(SortState *node)
 {
+        TS_MARKER(ExecSort_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	SO1_printf("ExecEndSort: %s\n",
 			   "shutting down sort node");
 

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -109,6 +109,7 @@ Datum pg_attribute_always_inline ExecSubPlan(SubPlanState *node,
   result = WrappedExecSubPlan(node, econtext, isNull);
 
   TS_MARKER(ExecSubPlan_end, node->planstate->plan->plan_node_id);
+  // TODO(Matt): Can't actually find a better place for this FEATURES Marker
   TS_MARKER(ExecSubPlan_features, node->planstate->plan->plan_node_id,
             node->planstate->state->es_plannedstmt->queryId,
             castNode(SubPlanState, node), node->planstate->plan);

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -170,6 +170,9 @@ ExecInitSubqueryScan(SubqueryScan *node, EState *estate, int eflags)
 void
 ExecEndSubqueryScan(SubqueryScanState *node)
 {
+        TS_MARKER(ExecSubqueryScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	/*
 	 * Free the exprcontext
 	 */

--- a/src/backend/executor/nodeTableFuncscan.c
+++ b/src/backend/executor/nodeTableFuncscan.c
@@ -216,6 +216,8 @@ ExecInitTableFuncScan(TableFuncScan *node, EState *estate, int eflags)
 void
 ExecEndTableFuncScan(TableFuncScanState *node)
 {
+      TS_MARKER(ExecTableFuncScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
 	/*
 	 * Free the exprcontext
 	 */

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -470,6 +470,9 @@ ExecReScanTidScan(TidScanState *node)
 void
 ExecEndTidScan(TidScanState *node)
 {
+        TS_MARKER(ExecTidScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	if (node->ss.ss_currentScanDesc)
 		table_endscan(node->ss.ss_currentScanDesc);
 

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -171,6 +171,9 @@ ExecInitUnique(Unique *node, EState *estate, int eflags)
 void
 ExecEndUnique(UniqueState *node)
 {
+        TS_MARKER(ExecUnique_features, node->ps.plan->plan_node_id,
+            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+
 	/* clean up tuple table */
 	ExecClearTuple(node->ps.ps_ResultTupleSlot);
 

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -331,6 +331,9 @@ ExecInitValuesScan(ValuesScan *node, EState *estate, int eflags)
 void
 ExecEndValuesScan(ValuesScanState *node)
 {
+      TS_MARKER(ExecValuesScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	/*
 	 * Free both exprcontexts
 	 */

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -2538,6 +2538,9 @@ ExecEndWindowAgg(WindowAggState *node)
 	PlanState  *outerPlan;
 	int			i;
 
+        TS_MARKER(ExecWindowAgg_features, node->ss.ps.plan->plan_node_id,
+                  node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+
 	release_partition(node);
 
 	ExecClearTuple(node->ss.ss_ScanTupleSlot);

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -192,6 +192,8 @@ ExecInitWorkTableScan(WorkTableScan *node, EState *estate, int eflags)
 void
 ExecEndWorkTableScan(WorkTableScanState *node)
 {
+        TS_MARKER(ExecWorkTableScan_features, node->ss.ps.plan->plan_node_id,
+            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
 	/*
 	 * Free exprcontext
 	 */

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -17,13 +17,6 @@
 #define TS_EXECUTOR_WRAPPER(node_type)                                         \
   static TupleTableSlot *Exec##node_type(PlanState *pstate) {                  \
     TupleTableSlot *result;                                                    \
-    TS_MARKER(Exec##node_type##_begin, pstate->plan->plan_node_id);            \
-                                                                               \
     result = WrappedExec##node_type(pstate);                                   \
-                                                                               \
-    TS_MARKER(Exec##node_type##_end, pstate->plan->plan_node_id);              \
-    TS_MARKER(Exec##node_type##_features, pstate->plan->plan_node_id,          \
-              pstate->state->es_plannedstmt->queryId,                          \
-              castNode(node_type##State, pstate), pstate->plan);               \
     return result;                                                             \
   }

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -17,6 +17,10 @@
 #define TS_EXECUTOR_WRAPPER(node_type)                                         \
   static TupleTableSlot *Exec##node_type(PlanState *pstate) {                  \
     TupleTableSlot *result;                                                    \
+    TS_MARKER(Exec##node_type##_begin, pstate->plan->plan_node_id);            \
+                                                                               \
     result = WrappedExec##node_type(pstate);                                   \
+                                                                               \
+    TS_MARKER(Exec##node_type##_end, pstate->plan->plan_node_id);              \
     return result;                                                             \
   }


### PR DESCRIPTION
### Background
We want to shift to accumulate the resource metrics (Ys) of the per-tuple invocations and assign those to a single X from the physical operator. This solves the scenarios where:
- Xs were fluctuating as the `<Blah>State` nodes changed but Ys were fairly fixed.
- Ys were fluctuating as the `<Blah>State` and `Plan` nodes were fixed.

This should also make the Xs coming out of the optimizer map more directly to the Ys.

### Changes
- Move the FEATURES marker to a node's teardown function, rather than in Exec (think Next() for Postgres)
- Add helper code to BPF to accumulate metrics structs
- Split incomplete metrics for an OU to 2 maps: one for the metrics being accumulated, and another for running metrics (snapshots)

### Discussion
The net result is significantly fewer training data points that should hopefully yield better results. For example, here is a sample sequential scan on 3 tuples before and after:
[ExecSeqScan_old.csv](https://github.com/cmu-db/postgres/files/7530902/ExecSeqScan_old.csv)
[ExecSeqScan_new.csv](https://github.com/cmu-db/postgres/files/7530903/ExecSeqScan_new.csv)
