### PR TITLE
ClangParser refinements

### DIFF
--- a/cmudb/tscout/clang_parser.py
+++ b/cmudb/tscout/clang_parser.py
@@ -82,7 +82,7 @@ class ClangParser:
             for node in translation_units[-1].cursor.get_children():
                 if node.kind in [clang.cindex.CursorKind.CLASS_DECL,
                                  clang.cindex.CursorKind.STRUCT_DECL,
-                                 clang.cindex.CursorKind.TYPEDEF_DECL,
+                                 clang.cindex.CursorKind.TYPEDEF_DECL,  # Fixes definition of instr_time
                                  clang.cindex.CursorKind.UNION_DECL] \
                         and node.is_definition() \
                         and node.spelling not in classes:

--- a/cmudb/tscout/clang_parser.py
+++ b/cmudb/tscout/clang_parser.py
@@ -82,10 +82,10 @@ class ClangParser:
             for node in translation_units[-1].cursor.get_children():
                 if node.kind in [clang.cindex.CursorKind.CLASS_DECL,
                                  clang.cindex.CursorKind.STRUCT_DECL,
-                                 clang.cindex.CursorKind.TYPEDEF_DECL,  # Fixes definition of instr_time
+                                 clang.cindex.CursorKind.TYPEDEF_DECL,  # Fixes definition of instr_time in instr_time.h
                                  clang.cindex.CursorKind.UNION_DECL] \
-                        and node.is_definition() \
-                        and node.spelling not in classes:
+                        and node.spelling not in classes \
+                        and node.is_definition():  # Fixes forward declarations clobbering definitions
                     classes[node.spelling] = node
 
         # To construct the field map, we will construct the following objects:

--- a/src/include/access/attnum.h
+++ b/src/include/access/attnum.h
@@ -14,7 +14,6 @@
 #ifndef ATTNUM_H
 #define ATTNUM_H
 
-#include "c.h"
 
 /*
  * user defined attribute numbers start at 1.   -ay 2/95

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -23,7 +23,6 @@
 #include "nodes/plannodes.h"
 #include "nodes/tidbitmap.h"
 #include "partitioning/partdefs.h"
-#include "postgres.h"
 #include "storage/condition_variable.h"
 #include "utils/hsearch.h"
 #include "utils/queryenvironment.h"


### PR DESCRIPTION
This is some groundwork for future plans.

### Changes:
- Can take in a list of files to parse. Uses a dictionary to build up the class list now to avoid duplicate definitions.
- Scrape config.log to extract the preprocessor definitions used at compile time. This is in the hope of making sure structs that vary in size based on environment aren't using the wrong values.

### Review remarks:
- [x]  I don't speak list comprehensions and Mappings. Maybe @lmwnshn can make my code less terrible.
- [x]  `convert_define_to_arg` could probably be done with regex, but that's more of a style choice if the current approach offends anyone.
- [x] Those 2 `#includes` that I removed were from early attempts at this and merged with #8. I'm not sure they're necessary anymore.

### Future work:
- The only missing information from the parsing pass currently is an anonymous union, but I'm not sure how to handle that. Will cross that bridge if it becomes an issue.