### PR TITLE
Revert "ClangParser refinements (#24)"

### DIFF
--- a/src/include/access/attnum.h
+++ b/src/include/access/attnum.h
@@ -14,6 +14,7 @@
 #ifndef ATTNUM_H
 #define ATTNUM_H
 
+#include "c.h"
 
 /*
  * user defined attribute numbers start at 1.   -ay 2/95

--- a/src/include/nodes/execnodes.h
+++ b/src/include/nodes/execnodes.h
@@ -23,6 +23,7 @@
 #include "nodes/plannodes.h"
 #include "nodes/tidbitmap.h"
 #include "partitioning/partdefs.h"
+#include "postgres.h"
 #include "storage/condition_variable.h"
 #include "utils/hsearch.h"
 #include "utils/queryenvironment.h"


### PR DESCRIPTION
This reverts commit 5e2c09a8cc5045a2c9e6179c253063ffa877659d.

Something's busted and don't have time to look at it right now.

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/multiprocessing/process.py", line 315, in _bootstrap
    self.run()
  File "/usr/lib/python3.8/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "tscout.py", line 97, in collector
    collector_c += generate_markers(ou, ou_index)
  File "tscout.py", line 74, in generate_markers
    generate_readargs(operation.features_list))
  File "tscout.py", line 45, in generate_readargs
    first_member = feature.bpf_tuple[0].name
IndexError: tuple index out of range
```