### PR TITLE
Remove execnodes from input features since they require query execution

### DIFF
--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -109,217 +109,181 @@ OU_DEFS = [
     ("ExecAgg",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("AggState"),
          Feature("Agg")
      ]),
     ("ExecAppend",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("AppendState"),
          Feature("Append")
      ]),
     ("ExecCteScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("CteScanState"),
          Feature("CteScan")
      ]),
     ("ExecCustomScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("CustomScanState"),
          Feature("CustomScan")
      ]),
     ("ExecForeignScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ForeignScanState"),
          Feature("ForeignScan")
      ]),
     ("ExecFunctionScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("FunctionScanState"),
          Feature("FunctionScan")
      ]),
     ("ExecGather",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("GatherState"),
          Feature("Gather")
      ]),
     ("ExecGatherMerge",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("GatherMergeState"),
          Feature("GatherMerge")
      ]),
     ("ExecGroup",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("GroupState"),
          Feature("Group")
      ]),
     ("ExecHashJoinImpl",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("HashJoinState"),
          Feature("HashJoin")
      ]),
     ("ExecIncrementalSort",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IncrementalSortState"),
          Feature("IncrementalSort")
      ]),
     ("ExecIndexOnlyScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IndexOnlyScanState"),
          Feature("IndexOnlyScan")
      ]),
     ("ExecIndexScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IndexScanState"),
          Feature("IndexScan")
      ]),
     ("ExecLimit",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("LimitState"),
          Feature("Limit")
      ]),
     ("ExecLockRows",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("LockRowsState"),
          Feature("LockRows")
      ]),
     ("ExecMaterial",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MaterialState"),
          Feature("Material")
      ]),
     ("ExecMergeAppend",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MergeAppendState"),
          Feature("MergeAppend")
      ]),
     ("ExecMergeJoin",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MergeJoinState"),
          Feature("MergeJoin")
      ]),
     ("ExecModifyTable",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ModifyTableState"),
          Feature("ModifyTable")
      ]),
     ("ExecNamedTuplestoreScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("NamedTuplestoreScanState"),
          Feature("NamedTuplestoreScan")
      ]),
     ("ExecNestLoop",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("NestLoopState"),
          Feature("NestLoop")
      ]),
     ("ExecProjectSet",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ProjectSetState"),
          Feature("ProjectSet")
      ]),
     ("ExecRecursiveUnion",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("RecursiveUnionState"),
          Feature("RecursiveUnion")
      ]),
     ("ExecResult",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ResultState"),
          Feature("Result")
      ]),
     ("ExecSampleScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SampleScanState"),
          Feature("SampleScan")
      ]),
     ("ExecSeqScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SeqScanState"),
          Feature("Scan")
      ]),
     ("ExecSetOp",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SetOpState"),
          Feature("SetOp")
      ]),
     ("ExecSort",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SortState"),
          Feature("Sort")
      ]),
     ("ExecSubPlan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SubPlan"),
          Feature("Plan")
      ]),
     ("ExecSubqueryScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SubqueryScanState"),
          Feature("SubqueryScan")
      ]),
     ("ExecTableFuncScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("TableFuncScanState"),
          Feature("TableFuncScan")
      ]),
     ("ExecTidScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("TidScanState"),
          Feature("TidScan")
      ]),
     ("ExecUnique",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("UniqueState"),
          Feature("Unique")
      ]),
     ("ExecValuesScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ValuesScanState"),
          Feature("ValuesScan")
      ]),
     ("ExecWindowAgg",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("WindowAggState"),
          Feature("WindowAgg")
      ]),
     ("ExecWorkTableScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("WorkTableScanState"),
          Feature("WorkTableScan")
      ]),
 ]

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -4383,7 +4383,7 @@ ExecEndAgg(AggState *node)
 	int			setno;
 
         TS_MARKER(ExecAgg_features, node->ss.ps.plan->plan_node_id,
-                  node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+                  node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * When ending a parallel worker, copy the statistics gathered by the

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -401,7 +401,7 @@ ExecEndAppend(AppendState *node)
 	int			i;
 
         TS_MARKER(ExecAppend_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 
 	/*
 	 * get information from the node

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -291,7 +291,7 @@ ExecEndCteScan(CteScanState *node)
 {
 
         TS_MARKER(ExecCteScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * Free exprcontext

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -123,7 +123,7 @@ ExecEndCustomScan(CustomScanState *node)
 {
 
         TS_MARKER(ExecCustomScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	Assert(node->methods->EndCustomScan != NULL);
 	node->methods->EndCustomScan(node);

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -293,7 +293,7 @@ ExecEndForeignScan(ForeignScanState *node)
 	EState	   *estate = node->ss.ps.state;
 
         TS_MARKER(ExecForeignScan_features, node->ss.ps.plan->plan_node_id,
-                  node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+                  node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/* Let the FDW shut down */
 	if (plan->operation != CMD_SELECT)

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -527,7 +527,7 @@ ExecEndFunctionScan(FunctionScanState *node)
 	int			i;
 
         TS_MARKER(ExecFunctionScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * Free the exprcontext

--- a/src/backend/executor/nodeGather.c
+++ b/src/backend/executor/nodeGather.c
@@ -252,7 +252,7 @@ void
 ExecEndGather(GatherState *node)
 {
         TS_MARKER(ExecGather_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 	ExecEndNode(outerPlanState(node));	/* let children clean up first */
 	ExecShutdownGather(node);
 	ExecFreeExprContext(&node->ps);

--- a/src/backend/executor/nodeGatherMerge.c
+++ b/src/backend/executor/nodeGatherMerge.c
@@ -292,7 +292,7 @@ void
 ExecEndGatherMerge(GatherMergeState *node)
 {
         TS_MARKER(ExecGatherMerge_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 	ExecEndNode(outerPlanState(node));	/* let children clean up first */
 	ExecShutdownGatherMerge(node);
 	ExecFreeExprContext(&node->ps);

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -232,7 +232,7 @@ ExecEndGroup(GroupState *node)
 	PlanState  *outerPlan;
 
         TS_MARKER(ExecGroup_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	ExecFreeExprContext(&node->ss.ps);
 

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -779,7 +779,7 @@ ExecEndHashJoin(HashJoinState *node)
 {
 
         TS_MARKER(ExecHashJoinImpl_features, node->js.ps.plan->plan_node_id,
-            node->js.ps.state->es_plannedstmt->queryId, node, node->js.ps.plan);
+            node->js.ps.state->es_plannedstmt->queryId, node->js.ps.plan);
 
         /*
 	 * Free hash table

--- a/src/backend/executor/nodeIncrementalSort.c
+++ b/src/backend/executor/nodeIncrementalSort.c
@@ -1079,7 +1079,7 @@ void
 ExecEndIncrementalSort(IncrementalSortState *node)
 {
         TS_MARKER(ExecIncrementalSort_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 	SO_printf("ExecEndIncrementalSort: shutting down sort node\n");
 
 	/* clean out the scan tuple */

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -375,7 +375,7 @@ ExecEndIndexOnlyScan(IndexOnlyScanState *node)
 	IndexScanDesc indexScanDesc;
 
         TS_MARKER(ExecIndexOnlyScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * extract information from the node

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -789,7 +789,7 @@ ExecEndIndexScan(IndexScanState *node)
 	IndexScanDesc indexScanDesc;
 
         TS_MARKER(ExecIndexScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * extract information from the node

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -361,7 +361,7 @@ recompute_limits(LimitState *node)
 	bool		isNull;
 
         TS_MARKER(ExecLimit_features, node->ps.plan->plan_node_id,
-                  node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+                  node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 
 	if (node->limitOffset)
 	{

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -389,7 +389,7 @@ void
 ExecEndLockRows(LockRowsState *node)
 {
         TS_MARKER(ExecLockRows_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 
 	/* We may have shut down EPQ already, but no harm in another call */
 	EvalPlanQualEnd(&node->lr_epqstate);

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -243,7 +243,7 @@ void
 ExecEndMaterial(MaterialState *node)
 {
         TS_MARKER(ExecMaterial_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * clean out the tuple table

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -339,7 +339,7 @@ ExecEndMergeAppend(MergeAppendState *node)
 	int			i;
 
         TS_MARKER(ExecMergeAppend_features, node->ps.plan->plan_node_id,
-                  node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+                  node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 
 	/*
 	 * get information from the node

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1635,7 +1635,7 @@ void
 ExecEndMergeJoin(MergeJoinState *node)
 {
         TS_MARKER(ExecMergeJoin_features, node->js.ps.plan->plan_node_id,
-            node->js.ps.state->es_plannedstmt->queryId, node, node->js.ps.plan);
+            node->js.ps.state->es_plannedstmt->queryId, node->js.ps.plan);
 
 	MJ1_printf("ExecEndMergeJoin: %s\n",
 			   "ending node processing");

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -3174,7 +3174,7 @@ ExecEndModifyTable(ModifyTableState *node)
 	int			i;
 
         TS_MARKER(ExecModifyTable_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 
 	/*
 	 * Allow any FDWs to shut down

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -167,7 +167,7 @@ void
 ExecEndNamedTuplestoreScan(NamedTuplestoreScanState *node)
 {
         TS_MARKER(ExecNamedTuplestoreScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * Free exprcontext

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -365,7 +365,7 @@ void
 ExecEndNestLoop(NestLoopState *node)
 {
         TS_MARKER(ExecNestLoop_features, node->js.ps.plan->plan_node_id,
-            node->js.ps.state->es_plannedstmt->queryId, node, node->js.ps.plan);
+            node->js.ps.state->es_plannedstmt->queryId, node->js.ps.plan);
 
 	NL1_printf("ExecEndNestLoop: %s\n",
 			   "ending node processing");

--- a/src/backend/executor/nodeProjectSet.c
+++ b/src/backend/executor/nodeProjectSet.c
@@ -324,7 +324,7 @@ void
 ExecEndProjectSet(ProjectSetState *node)
 {
         TS_MARKER(ExecProjectSet_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 
 	/*
 	 * Free the exprcontext

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -275,7 +275,7 @@ void
 ExecEndRecursiveUnion(RecursiveUnionState *node)
 {
         TS_MARKER(ExecRecursiveUnion_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 
 	/* Release tuplestores */
 	tuplestore_end(node->working_table);

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -244,7 +244,7 @@ void
 ExecEndResult(ResultState *node)
 {
         TS_MARKER(ExecResult_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 
 	/*
 	 * Free the exprcontext

--- a/src/backend/executor/nodeSamplescan.c
+++ b/src/backend/executor/nodeSamplescan.c
@@ -185,7 +185,7 @@ void
 ExecEndSampleScan(SampleScanState *node)
 {
         TS_MARKER(ExecSampleScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * Tell sampling function that we finished the scan.

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -188,7 +188,7 @@ ExecEndSeqScan(SeqScanState *node)
 	TableScanDesc scanDesc;
 
         TS_MARKER(ExecSeqScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * get information from node

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -586,7 +586,7 @@ void
 ExecEndSetOp(SetOpState *node)
 {
         TS_MARKER(ExecSetOp_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 
 	/* clean up tuple table */
 	ExecClearTuple(node->ps.ps_ResultTupleSlot);

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -238,7 +238,7 @@ void
 ExecEndSort(SortState *node)
 {
         TS_MARKER(ExecSort_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	SO1_printf("ExecEndSort: %s\n",
 			   "shutting down sort node");

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -112,7 +112,7 @@ Datum pg_attribute_always_inline ExecSubPlan(SubPlanState *node,
   // TODO(Matt): Can't actually find a better place for this FEATURES Marker
   TS_MARKER(ExecSubPlan_features, node->planstate->plan->plan_node_id,
             node->planstate->state->es_plannedstmt->queryId,
-            castNode(SubPlanState, node), node->planstate->plan);
+            node->planstate->plan);
 
   return result;
 }

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -171,7 +171,7 @@ void
 ExecEndSubqueryScan(SubqueryScanState *node)
 {
         TS_MARKER(ExecSubqueryScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * Free the exprcontext

--- a/src/backend/executor/nodeTableFuncscan.c
+++ b/src/backend/executor/nodeTableFuncscan.c
@@ -217,7 +217,7 @@ void
 ExecEndTableFuncScan(TableFuncScanState *node)
 {
       TS_MARKER(ExecTableFuncScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 	/*
 	 * Free the exprcontext
 	 */

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -471,7 +471,7 @@ void
 ExecEndTidScan(TidScanState *node)
 {
         TS_MARKER(ExecTidScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	if (node->ss.ss_currentScanDesc)
 		table_endscan(node->ss.ss_currentScanDesc);

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -172,7 +172,7 @@ void
 ExecEndUnique(UniqueState *node)
 {
         TS_MARKER(ExecUnique_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node, node->ps.plan);
+            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
 
 	/* clean up tuple table */
 	ExecClearTuple(node->ps.ps_ResultTupleSlot);

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -332,7 +332,7 @@ void
 ExecEndValuesScan(ValuesScanState *node)
 {
       TS_MARKER(ExecValuesScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * Free both exprcontexts

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -2539,7 +2539,7 @@ ExecEndWindowAgg(WindowAggState *node)
 	int			i;
 
         TS_MARKER(ExecWindowAgg_features, node->ss.ps.plan->plan_node_id,
-                  node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+                  node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	release_partition(node);
 

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -193,7 +193,7 @@ void
 ExecEndWorkTableScan(WorkTableScanState *node)
 {
         TS_MARKER(ExecWorkTableScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node, node->ss.ps.plan);
+            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 	/*
 	 * Free exprcontext
 	 */


### PR DESCRIPTION
As discussed in recent meetings.