### PR TITLE
Boilerplate to extract background postgres worker PIDs

### DIFF
--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 import multiprocessing as mp
 import sys
-from typing import List
 
 from dataclasses import dataclass
 import psutil

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -44,7 +44,7 @@ class PostgresInstance:
                 elif all(x is not None for x in [self.checkpointer_pid, self.bgwriter_pid, self.walwriter_pid]):
                     # We found all the children PIDs that we care about, so we're done.
                     return
-        except psutil.NoSuchProcess as e:
+        except psutil.NoSuchProcess:
             logger.error("Provided PID not found.")
             exit()
 

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -13,7 +13,7 @@ import model
 
 
 @dataclass
-class Postgres:
+class PostgresInstance:
     def __init__(self, pid):
         self.postgres_pid = pid
         try:
@@ -287,16 +287,16 @@ if __name__ == '__main__':
         exit()
     pid = int(sys.argv[1])
 
-    thing = Postgres(pid)
+    postgres = PostgresInstance(pid)
 
-    setproctitle.setproctitle("{} TScout".format(pid))
+    setproctitle.setproctitle("{} TScout".format(postgres.postgres_pid))
 
     # Read the C code for TScout.
     with open('tscout.c', 'r') as tscout_file:
         tscout_c = tscout_file.read()
 
     # Attach USDT probes to the target PID.
-    tscout_probes = USDT(pid=int(pid))
+    tscout_probes = USDT(pid=postgres.postgres_pid)
     for probe in ['fork_backend', 'fork_background',
                   'reap_backend', 'reap_background']:
         tscout_probes.enable_probe(probe=probe, fn_name=probe)
@@ -370,7 +370,7 @@ if __name__ == '__main__':
         tscout_bpf["postmaster_events"].open_perf_buffer(
             callback=postmaster_event, lost_cb=lost_something)
 
-        print("TScout attached to PID {}.".format(pid))
+        print("TScout attached to PID {}.".format(postgres.postgres_pid))
 
         # Poll on TScout's output buffer until TScout is shut down.
         while keep_running:
@@ -404,6 +404,6 @@ if __name__ == '__main__':
         for ou_processor in ou_processors:
             ou_processor.join()
         print("TScout joined all Processors.")
-        print("TScout for PID {} shut down.".format(pid))
+        print("TScout for PID {} shut down.".format(postgres.postgres_pid))
         # We're done.
         exit()

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -18,6 +18,17 @@ class PostgresInstance:
     def __init__(self, pid):
 
         def cmd_in_cmdline(cmd, proc):
+            """
+
+            Parameters
+            ----------
+            cmd: str
+            proc: psutil.Process
+
+            Returns
+            -------
+            True if the provided command was in the provided Process' command line args.
+            """
             return any(cmd in x for x in proc.cmdline())
 
         self.postgres_pid = pid


### PR DESCRIPTION
Decided to leave the postmaster PID as a command line arg to TScout for the scenario where there are multiple Postgres instances. The launching script can coordinate that.