### PR TITLE
Move Features Marker before Begin/End, add Flush marker

### DIFF
--- a/cmudb/tscout/collector.c
+++ b/cmudb/tscout/collector.c
@@ -18,9 +18,9 @@ BPF_PERF_ARRAY(cache_misses, MAX_CPUS);
 BPF_PERF_ARRAY(ref_cpu_cycles, MAX_CPUS);
 
 // Stores accumulated metrics, waiting to hit a FEATURES Marker
-BPF_HASH(complete_metrics, u64, struct resource_metrics, 32);  // TODO(Matt: Think about this size more
+BPF_HASH(complete_metrics, u64, struct resource_metrics, 32);  // TODO(Matt): Think about this size more
 // Stores a snapshot of the metrics at START Marker, waiting to hit an END Marker
-BPF_HASH(running_metrics, u64, struct resource_metrics, 32);  // TODO(Matt: Think about this size more
+BPF_HASH(running_metrics, u64, struct resource_metrics, 32);  // TODO(Matt): Think about this size more
 
 // We expect `plan_node_id` to be unique within the call stack, even if OUs are recursive.
 static u64 ou_key(const u32 ou, const s32 ou_instance) { return ((u64)ou) << 32 | ou_instance; }

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -22,7 +22,7 @@ static void SUBST_OU_reset(s32 ou_instance) {
 
 void SUBST_OU_begin(struct pt_regs *ctx) {
   // TODO(Matt): Check running_features (NULL) or running_metrics (non-NULL) to see if our state machine is busted.
-  s32 ou_instance;
+  s32 ou_instance = 0;
   bpf_usdt_readarg(1, ctx, &ou_instance);
   u64 key = ou_key(SUBST_INDEX, ou_instance);
 
@@ -49,10 +49,11 @@ void SUBST_OU_begin(struct pt_regs *ctx) {
 
 void SUBST_OU_end(struct pt_regs *ctx) {
   // Retrieve start metrics
-  struct resource_metrics *metrics = NULL;
-  s32 ou_instance;
+  s32 ou_instance = 0;
   bpf_usdt_readarg(1, ctx, &ou_instance);
   u64 key = ou_key(SUBST_INDEX, ou_instance);
+
+  struct resource_metrics *metrics = NULL;
   metrics = running_metrics.lookup(&key);
   if (metrics == NULL) {
     SUBST_OU_reset(ou_instance);
@@ -111,7 +112,7 @@ void SUBST_OU_features(struct pt_regs *ctx) {
   SUBST_READARGS
 
   // Store the start metrics in the subsystem map, waiting for end
-  s32 ou_instance;
+  s32 ou_instance = 0;
   bpf_usdt_readarg(1, ctx, &ou_instance);
   SUBST_OU_complete_features.update(&ou_instance, features);
 }
@@ -126,7 +127,7 @@ BPF_ARRAY(SUBST_OU_output_arr, struct SUBST_OU_output, 1);
 BPF_PERF_OUTPUT(collector_results_SUBST_INDEX);
 
 void SUBST_OU_flush(struct pt_regs *ctx) {
-  s32 ou_instance;
+  s32 ou_instance = 0;
   bpf_usdt_readarg(1, ctx, &ou_instance);
   u64 key = ou_key(SUBST_INDEX, ou_instance);
 

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -27,18 +27,18 @@ void SUBST_OU_begin(struct pt_regs *ctx) {
   metrics.start_time = (bpf_ktime_get_ns() >> 10);
 
   // Store the start metrics in the subsystem map, waiting for end
-  s32 plan_node_id;
-  bpf_usdt_readarg(1, ctx, &plan_node_id);
-  u64 key = ou_key(SUBST_INDEX, plan_node_id);
+  s32 ou_instance;
+  bpf_usdt_readarg(1, ctx, &ou_instance);
+  u64 key = ou_key(SUBST_INDEX, ou_instance);
   running_metrics.update(&key, &metrics);
 }
 
 void SUBST_OU_end(struct pt_regs *ctx) {
   // Retrieve start metrics
   struct resource_metrics *metrics = NULL;
-  s32 plan_node_id;
-  bpf_usdt_readarg(1, ctx, &plan_node_id);
-  u64 key = ou_key(SUBST_INDEX, plan_node_id);
+  s32 ou_instance;
+  bpf_usdt_readarg(1, ctx, &ou_instance);
+  u64 key = ou_key(SUBST_INDEX, ou_instance);
   metrics = running_metrics.lookup(&key);
   if (metrics == NULL) {
     return;
@@ -92,9 +92,9 @@ BPF_PERF_OUTPUT(collector_results_SUBST_INDEX);
 void SUBST_OU_features(struct pt_regs *ctx) {
   // Retrieve completed metrics
   struct resource_metrics *metrics = NULL;
-  s32 plan_node_id;
-  bpf_usdt_readarg(1, ctx, &plan_node_id);
-  u64 key = ou_key(SUBST_INDEX, plan_node_id);
+  s32 ou_instance;
+  bpf_usdt_readarg(2, ctx, &ou_instance);
+  u64 key = ou_key(SUBST_INDEX, ou_instance);
   metrics = complete_metrics.lookup(&key);
   if (metrics == NULL || metrics->end_time == 0) {
     // Arrived at the FEATURES marker out of order.

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -126,6 +126,7 @@ void SUBST_OU_end(struct pt_regs *ctx) {
     features = SUBST_OU_complete_features.lookup(&ou_instance);
     if (features == NULL) {
       // TODO(Matt): we have no features. This data point is toast.
+      return;
     }
 
     // Copy completed features to output struct
@@ -163,5 +164,5 @@ void SUBST_OU_features(struct pt_regs *ctx) {
   // Store the start metrics in the subsystem map, waiting for end
   s32 ou_instance;
   bpf_usdt_readarg(1, ctx, &ou_instance);
-  running_metrics.update(&ou_instance, features);
+  SUBST_OU_complete_features.update(&ou_instance, features);
 }

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -16,10 +16,7 @@ BPF_ARRAY(SUBST_OU_features_arr, struct SUBST_OU_features, 1);
 
 // Reset the state of this OU instance. This is a general purpose function to call if the Marker state machine falls
 // apart.
-static void SUBST_OU_reset(s32 ou_instance, bool error) {
-  if (error) {
-    bpf_trace_printk("Invalid control flow. OU index: %d, OU instance %d\n", SUBST_INDEX, ou_instance);
-  }
+static void SUBST_OU_reset(s32 ou_instance) {
   u64 key = ou_key(SUBST_INDEX, ou_instance);
   SUBST_OU_complete_features.delete(&ou_instance);
   complete_metrics.delete(&key);

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -140,12 +140,11 @@ void SUBST_OU_end(struct pt_regs *ctx) {
     // Copy completed metrics to output struct
     __builtin_memcpy(&(output->SUBST_FIRST_METRIC), flush_metrics, sizeof(struct resource_metrics));
 
-    // This enforces the state machine of begin -> end -> features.
-    complete_metrics.delete(&key);
     // The SUBST_OU_output_arr does not need to be deleted because it is memset to 0 every time.
 
     // Send output struct to userspace via subsystem's perf ring buffer
     collector_results_SUBST_INDEX.perf_submit(ctx, output, sizeof(struct SUBST_OU_output));
+    SUBST_OU_reset(ou_instance);
   }
 
   running_metrics.delete(&key);

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -9,7 +9,13 @@ struct SUBST_OU_output {
   SUBST_METRICS;   // Replaced by the list of metrics
 };
 
+// Stores a snapshot of the metrics at START Marker, waiting to hit an END Marker
+BPF_HASH(SUBST_OU_complete_features, s32, struct SUBST_OU_features, 32);  // TODO(Matt): Think about this size more
+BPF_ARRAY(SUBST_OU_features_arr, struct SUBST_OU_features, 1);
+
 void SUBST_OU_begin(struct pt_regs *ctx) {
+  // TODO(Matt): Check running_features (NULL) or running_metrics (non-NULL) to see if our state machine is busted.
+
   // Zero initialize start metrics
   struct resource_metrics metrics = {};
 
@@ -33,20 +39,31 @@ void SUBST_OU_begin(struct pt_regs *ctx) {
   running_metrics.update(&key, &metrics);
 }
 
+// A BPF array is defined because the OU output struct is typically larger
+// than the 512 byte stack limit imposed by BPF.
+BPF_ARRAY(SUBST_OU_output_arr, struct SUBST_OU_output, 1);
+// A BPF perf output buffer is defined per OU because the labels being
+// emitted are different for each OU. Previously, using only one perf output
+// buffer resulted in using the labels of the last perf_submit caller in the
+// source code, which was incorrect.
+BPF_PERF_OUTPUT(collector_results_SUBST_INDEX);
+
 void SUBST_OU_end(struct pt_regs *ctx) {
   // Retrieve start metrics
   struct resource_metrics *metrics = NULL;
   s32 ou_instance;
-  bpf_usdt_readarg(1, ctx, &ou_instance);
+  bpf_usdt_readarg(2, ctx, &ou_instance);
   u64 key = ou_key(SUBST_INDEX, ou_instance);
   metrics = running_metrics.lookup(&key);
   if (metrics == NULL) {
+    // TODO(Matt): delete features and complete metrics too because this data point is toast?
     return;
   }
 
   if (metrics->end_time != 0) {
     // Arrived at the END marker out of order.
     running_metrics.delete(&key);
+    // TODO(Matt): delete features and complete metrics too because this data point is toast?
     return;
   }
 
@@ -57,6 +74,7 @@ void SUBST_OU_end(struct pt_regs *ctx) {
   // Probe for CPU counters
   if (!cpu_end(metrics)) {
     running_metrics.delete(&key);
+    // TODO(Matt): delete features and complete metrics too because this data point is toast?
     return;
   }
   struct task_struct *p = (struct task_struct *)bpf_get_current_task();
@@ -65,35 +83,72 @@ void SUBST_OU_end(struct pt_regs *ctx) {
   net_end(metrics, p, CLIENT_SOCKET_FD);
 #endif
 
-  // Store the completed metrics in the subsystem map, waiting for features
+  // Find out if we should flush, and if we have previously stored metrics for this OU invocation to accumulate.
+  bool flush;
+  bpf_usdt_readarg(1, ctx, &flush);
   struct resource_metrics *accumulated_metrics = NULL;
   accumulated_metrics = complete_metrics.lookup(&key);
-  if (accumulated_metrics == NULL) {
-    // They don't exist yet, but that's okay, this could be the first tuple. Just drop in the END instance's
-    // metrics as the complete ones.
-    complete_metrics.update(&key, metrics);
-  } else {
-    // We have accumulated metrics already. Let's add them.
+
+  struct resource_metrics *flush_metrics = NULL;
+  if (accumulated_metrics != NULL) {
+    // We have accumulated metrics already. Let's add this data point to the previous metrics.
     metrics_accumulate(accumulated_metrics, metrics);
+    // If we flush, it'll be the accumulated metrics.
+    flush_metrics = accumulated_metrics;
+  } else {
+    if (!flush) {
+      // Only store completed metrics for a future accumulation if we're not flushing, otherwise it's wasted work.
+      complete_metrics.update(&key, metrics);
+    }
+    // If we flush, we'll use the now-complete running metrics from this invocation.
+    flush_metrics = metrics;
+  }
+
+  if (flush) {
+    // Look up complete_features.
+    // memcpy features into output_arr
+    // memcpy flush_pointer into output_arr
+    // Zero initialize output struct for features and metrics
+    int idx = 0;
+    struct SUBST_OU_output *output = SUBST_OU_output_arr.lookup(&idx);
+    if (output == NULL) {
+      // This should never happen and should be considered a fatal error.
+      return;
+    }
+    memset(output, 0, sizeof(struct SUBST_OU_output));
+
+    // Set the index of this SUBST_OU.
+    output->ou_index = SUBST_INDEX;
+
+    // Retrieve the features
+    struct SUBST_OU_features *features = NULL;
+    features = SUBST_OU_complete_features.lookup(&ou_instance);
+    if (features == NULL) {
+      // TODO(Matt): we have no features. This data point is toast.
+    }
+
+    // Copy completed features to output struct
+    __builtin_memcpy(&(output->SUBST_FIRST_FEATURE), features, sizeof(struct SUBST_OU_features));
+
+    // Copy completed metrics to output struct
+    __builtin_memcpy(&(output->SUBST_FIRST_METRIC), flush_metrics, sizeof(struct resource_metrics));
+
+    // This enforces the state machine of begin -> end -> features.
+    complete_metrics.delete(&key);
+    // The SUBST_OU_output_arr does not need to be deleted because it is memset to 0 every time.
+
+    // Send output struct to userspace via subsystem's perf ring buffer
+    collector_results_SUBST_INDEX.perf_submit(ctx, output, sizeof(struct SUBST_OU_output));
   }
 
   running_metrics.delete(&key);
 }
 
-// A BPF array is defined because the OU output struct is typically larger
-// than the 512 byte stack limit imposed by BPF.
-BPF_ARRAY(SUBST_OU_output_arr, struct SUBST_OU_output, 1);
-// A BPF perf output buffer is defined per OU because the labels being
-// emitted are different for each OU. Previously, using only one perf output
-// buffer resulted in using the labels of the last perf_submit caller in the
-// source code, which was incorrect.
-BPF_PERF_OUTPUT(collector_results_SUBST_INDEX);
-
 void SUBST_OU_features(struct pt_regs *ctx) {
   // Retrieve completed metrics
   struct resource_metrics *metrics = NULL;
   s32 ou_instance;
-  bpf_usdt_readarg(2, ctx, &ou_instance);
+  bpf_usdt_readarg(1, ctx, &ou_instance);
   u64 key = ou_key(SUBST_INDEX, ou_instance);
   metrics = complete_metrics.lookup(&key);
   if (metrics == NULL || metrics->end_time == 0) {
@@ -103,25 +158,16 @@ void SUBST_OU_features(struct pt_regs *ctx) {
 
   // Zero initialize output struct for features and metrics
   int idx = 0;
-  struct SUBST_OU_output *output = SUBST_OU_output_arr.lookup(&idx);
-  if (output == NULL) {
+  struct SUBST_OU_features *features = SUBST_OU_complete_features.lookup(&idx);
+  if (features == NULL) {
+    // This should never happen and should be considered a fatal error.
     return;
   }
-  memset(output, 0, sizeof(struct SUBST_OU_output));
+  memset(output, 0, sizeof(struct SUBST_OU_features));
 
-  // Set the index of this SUBST_OU.
-  output->ou_index = SUBST_INDEX;
-
-  // Copy completed metrics to output struct
-  __builtin_memcpy(&(output->start_time), metrics, sizeof(struct resource_metrics));
 
   // Copy features from USDT arg (pointer to features struct in NoisePage) to output struct
   SUBST_READARGS
 
-  // This enforces the state machine of begin -> end -> features.
-  complete_metrics.delete(&key);
-  // The SUBST_OU_output_arr does not need to be deleted because it is memset to 0 every time.
 
-  // Send output struct to userspace via subsystem's perf ring buffer
-  collector_results_SUBST_INDEX.perf_submit(ctx, output, sizeof(struct SUBST_OU_output));
 }

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -34,7 +34,7 @@ void SUBST_OU_begin(struct pt_regs *ctx) {
   // Probe for CPU counters
   if (!cpu_start(&metrics)) {
     // This shouldn't happen, but best to handle failing to read PMC registers here and toss the data point.
-    SUBST_OU_reset(ou_instance, true);
+    SUBST_OU_reset(ou_instance);
     return;
   }
   struct task_struct *p = (struct task_struct *)bpf_get_current_task();
@@ -59,7 +59,7 @@ void SUBST_OU_end(struct pt_regs *ctx) {
   struct resource_metrics *metrics = NULL;
   metrics = running_metrics.lookup(&key);
   if (metrics == NULL) {
-    SUBST_OU_reset(ou_instance, true);
+    SUBST_OU_reset(ou_instance);
     return;
   }
 
@@ -73,7 +73,7 @@ void SUBST_OU_end(struct pt_regs *ctx) {
   // Probe for CPU counters
   if (!cpu_end(metrics)) {
     // This shouldn't happen, but best to handle failing to read PMC registers here and toss the data point.
-    SUBST_OU_reset(ou_instance, true);
+    SUBST_OU_reset(ou_instance);
     return;
   }
   struct task_struct *p = (struct task_struct *)bpf_get_current_task();
@@ -133,7 +133,7 @@ void SUBST_OU_flush(struct pt_regs *ctx) {
   features = SUBST_OU_complete_features.lookup(&ou_instance);
   if (features == NULL) {
     // We don't have any features for this data point.
-    SUBST_OU_reset(ou_instance, true);
+    SUBST_OU_reset(ou_instance);
     return;
   }
 
@@ -141,7 +141,7 @@ void SUBST_OU_flush(struct pt_regs *ctx) {
   flush_metrics = complete_metrics.lookup(&key);
   if (flush_metrics == NULL) {
     // We don't have any metrics for this data point.
-    SUBST_OU_reset(ou_instance, true);
+    SUBST_OU_reset(ou_instance);
     return;
   }
 
@@ -166,5 +166,5 @@ void SUBST_OU_flush(struct pt_regs *ctx) {
 
   // Send output struct to userspace via subsystem's perf ring buffer.
   collector_results_SUBST_INDEX.perf_submit(ctx, output, sizeof(struct SUBST_OU_output));
-  SUBST_OU_reset(ou_instance, false);
+  SUBST_OU_reset(ou_instance);
 }

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -11,9 +11,13 @@ struct SUBST_OU_output {
 
 // Stores a snapshot of the metrics at START Marker, waiting to hit an END Marker
 BPF_HASH(SUBST_OU_complete_features, s32, struct SUBST_OU_features, 32);  // TODO(Matt): Think about this size more
+// We can't assume that a features struct will fit on the stack, so we allocate an array of size 1 to use as scratch.
 BPF_ARRAY(SUBST_OU_features_arr, struct SUBST_OU_features, 1);
 
+// Reset the state of this OU instance. This is a general purpose function to call if the Marker state machine falls
+// apart.
 static void SUBST_OU_reset(s32 ou_instance) {
+  bpf_trace_printk("Invalid control flow. OU index: %d, OU instance %d", SUBST_INDEX, ou_instance);
   u64 key = ou_key(SUBST_INDEX, ou_instance);
   SUBST_OU_complete_features.delete(&ou_instance);
   complete_metrics.delete(&key);
@@ -21,7 +25,6 @@ static void SUBST_OU_reset(s32 ou_instance) {
 }
 
 void SUBST_OU_begin(struct pt_regs *ctx) {
-  // TODO(Matt): Check running_features (NULL) or running_metrics (non-NULL) to see if our state machine is busted.
   s32 ou_instance = 0;
   bpf_usdt_readarg(1, ctx, &ou_instance);
   u64 key = ou_key(SUBST_INDEX, ou_instance);
@@ -31,6 +34,7 @@ void SUBST_OU_begin(struct pt_regs *ctx) {
 
   // Probe for CPU counters
   if (!cpu_start(&metrics)) {
+    // This shouldn't happen, but best to handle failing to read PMC registers here and toss the data point.
     SUBST_OU_reset(ou_instance);
     return;
   }
@@ -60,18 +64,16 @@ void SUBST_OU_end(struct pt_regs *ctx) {
     return;
   }
 
-  if (metrics->end_time != 0) {
-    // Arrived at the END marker out of order.
-    SUBST_OU_reset(ou_instance);
-    return;
-  }
+  // TODO(Matt): Consider snapshotting end metrics before doing any other work in this Marker. I don't think work before
+  // this is enough to greatly alter measurements, but if it gets any more complicated...
 
-  // Collect an end time before probes are complete, converting from nanoseconds to microseconds
+  // Collect an end time before probes are complete, converting from nanoseconds to microseconds.
   metrics->end_time = (bpf_ktime_get_ns() >> 10);
   metrics->elapsed_us = (metrics->end_time - metrics->start_time);
 
   // Probe for CPU counters
   if (!cpu_end(metrics)) {
+    // This shouldn't happen, but best to handle failing to read PMC registers here and toss the data point.
     SUBST_OU_reset(ou_instance);
     return;
   }
@@ -85,11 +87,10 @@ void SUBST_OU_end(struct pt_regs *ctx) {
   struct resource_metrics *accumulated_metrics = NULL;
   accumulated_metrics = complete_metrics.lookup(&key);
   if (accumulated_metrics == NULL) {
-    // They don't exist yet, but that's okay, this could be the first tuple. Just drop in the END instance's
-    // metrics as the complete ones.
+    // We don't have any accumulated metrics. Use these metrics as the complete metrics.
     complete_metrics.update(&key, metrics);
   } else {
-    // We have accumulated metrics already. Let's add them.
+    // We have accumulated metrics already. Let's add these metrics to them.
     metrics_accumulate(accumulated_metrics, metrics);
   }
 
@@ -97,31 +98,28 @@ void SUBST_OU_end(struct pt_regs *ctx) {
 }
 
 void SUBST_OU_features(struct pt_regs *ctx) {
-  // TODO(Matt): Check complete_metrics (non-NULL) or running_metrics (non-NULL) to see if our state machine is busted.
-
-  // Zero initialize output struct for features and metrics
+  // Fetch scratch features struct
   int idx = 0;
   struct SUBST_OU_features *features = SUBST_OU_features_arr.lookup(&idx);
   if (features == NULL) {
-    // This should never happen and should be considered a fatal error.
+    bpf_trace_printk("Fatal error. Scratch array lookup failed.");
     return;
   }
   memset(features, 0, sizeof(struct SUBST_OU_features));
 
-  // Copy features from USDT arg (pointer to features struct in NoisePage) to output struct
+  // Copy features from USDT arg (pointer to features struct in NoisePage) to features struct.
   SUBST_READARGS
 
-  // Store the start metrics in the subsystem map, waiting for end
+  // Store the features, waiting for BEGIN, END, and FLUSH.
   s32 ou_instance = 0;
   bpf_usdt_readarg(1, ctx, &ou_instance);
   SUBST_OU_complete_features.update(&ou_instance, features);
 }
 
-// A BPF array is defined because the OU output struct is typically larger
-// than the 512 byte stack limit imposed by BPF.
+// We can't assume that an output struct will fit on the stack, so we allocate an array of size 1 to use as scratch.
 BPF_ARRAY(SUBST_OU_output_arr, struct SUBST_OU_output, 1);
 // A BPF perf output buffer is defined per OU because the labels being
-// emitted are different for each OU. Previously, using only one perf output
+// emitted are different for each OU. Using only one perf output
 // buffer resulted in using the labels of the last perf_submit caller in the
 // source code, which was incorrect.
 BPF_PERF_OUTPUT(collector_results_SUBST_INDEX);
@@ -131,35 +129,35 @@ void SUBST_OU_flush(struct pt_regs *ctx) {
   bpf_usdt_readarg(1, ctx, &ou_instance);
   u64 key = ou_key(SUBST_INDEX, ou_instance);
 
-  struct resource_metrics *flush_metrics = NULL;
-  flush_metrics = complete_metrics.lookup(&key);
-  if (flush_metrics == NULL) {
-    SUBST_OU_reset(ou_instance);
-    return;
-  }
-
-  // Look up complete_features.
-  // memcpy features into output_arr
-  // memcpy flush_pointer into output_arr
-  // Zero initialize output struct for features and metrics
-  int idx = 0;
-  struct SUBST_OU_output *output = SUBST_OU_output_arr.lookup(&idx);
-  if (output == NULL) {
-    // This should never happen and should be considered a fatal error.
-    return;
-  }
-  memset(output, 0, sizeof(struct SUBST_OU_output));
-
-  // Set the index of this SUBST_OU.
-  output->ou_index = SUBST_INDEX;
-
   // Retrieve the features
   struct SUBST_OU_features *features = NULL;
   features = SUBST_OU_complete_features.lookup(&ou_instance);
   if (features == NULL) {
+    // We don't have any features for this data point.
     SUBST_OU_reset(ou_instance);
     return;
   }
+
+  struct resource_metrics *flush_metrics = NULL;
+  flush_metrics = complete_metrics.lookup(&key);
+  if (flush_metrics == NULL) {
+    // We don't have any metrics for this data point.
+    SUBST_OU_reset(ou_instance);
+    return;
+  }
+
+  // Fetch scratch output struct.
+  int idx = 0;
+  struct SUBST_OU_output *output = SUBST_OU_output_arr.lookup(&idx);
+  if (output == NULL) {
+    bpf_trace_printk("Fatal error. Scratch array lookup failed.");
+    return;
+  }
+  // Zero initialize output struct for features and metrics
+  memset(output, 0, sizeof(struct SUBST_OU_output));
+
+  // Set the index of this SUBST_OU so the Collector knows which Processor to send this data point to.
+  output->ou_index = SUBST_INDEX;
 
   // Copy completed features to output struct
   __builtin_memcpy(&(output->SUBST_FIRST_FEATURE), features, sizeof(struct SUBST_OU_features));
@@ -167,9 +165,7 @@ void SUBST_OU_flush(struct pt_regs *ctx) {
   // Copy completed metrics to output struct
   __builtin_memcpy(&(output->SUBST_FIRST_METRIC), flush_metrics, sizeof(struct resource_metrics));
 
-  // The SUBST_OU_output_arr does not need to be deleted because it is memset to 0 every time.
-
-  // Send output struct to userspace via subsystem's perf ring buffer
+  // Send output struct to userspace via subsystem's perf ring buffer.
   collector_results_SUBST_INDEX.perf_submit(ctx, output, sizeof(struct SUBST_OU_output));
   SUBST_OU_reset(ou_instance);
 }

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -367,6 +367,9 @@ class OperatingUnit:
     def features_marker(self) -> str:
         return self.name() + '_features'
 
+    def flush_marker(self) -> str:
+        return self.name() + '_flush'
+
     def features_struct(self) -> str:
         """
         Returns

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -116,181 +116,181 @@ OU_DEFS = [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("Agg")
      ]),
-    ("ExecAppend",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Append")
-     ]),
-    ("ExecCteScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("CteScan")
-     ]),
-    ("ExecCustomScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("CustomScan")
-     ]),
-    ("ExecForeignScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ForeignScan")
-     ]),
-    ("ExecFunctionScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("FunctionScan")
-     ]),
-    ("ExecGather",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Gather")
-     ]),
-    ("ExecGatherMerge",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("GatherMerge")
-     ]),
-    ("ExecGroup",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Group")
-     ]),
-    ("ExecHashJoinImpl",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("HashJoin")
-     ]),
-    ("ExecIncrementalSort",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IncrementalSort")
-     ]),
-    ("ExecIndexOnlyScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IndexOnlyScan")
-     ]),
-    ("ExecIndexScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IndexScan")
-     ]),
-    ("ExecLimit",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Limit")
-     ]),
-    ("ExecLockRows",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("LockRows")
-     ]),
-    ("ExecMaterial",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Material")
-     ]),
-    ("ExecMergeAppend",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MergeAppend")
-     ]),
-    ("ExecMergeJoin",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MergeJoin")
-     ]),
-    ("ExecModifyTable",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ModifyTable")
-     ]),
-    ("ExecNamedTuplestoreScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("NamedTuplestoreScan")
-     ]),
-    ("ExecNestLoop",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("NestLoop")
-     ]),
-    ("ExecProjectSet",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ProjectSet")
-     ]),
-    ("ExecRecursiveUnion",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("RecursiveUnion")
-     ]),
-    ("ExecResult",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Result")
-     ]),
-    ("ExecSampleScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SampleScan")
-     ]),
-    ("ExecSeqScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Scan")
-     ]),
-    ("ExecSetOp",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SetOp")
-     ]),
-    ("ExecSort",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Sort")
-     ]),
-    ("ExecSubPlan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Plan")
-     ]),
-    ("ExecSubqueryScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SubqueryScan")
-     ]),
-    ("ExecTableFuncScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("TableFuncScan")
-     ]),
-    ("ExecTidScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("TidScan")
-     ]),
-    ("ExecUnique",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Unique")
-     ]),
-    ("ExecValuesScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ValuesScan")
-     ]),
-    ("ExecWindowAgg",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("WindowAgg")
-     ]),
-    ("ExecWorkTableScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("WorkTableScan")
-     ]),
+    # ("ExecAppend",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Append")
+    #  ]),
+    # ("ExecCteScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("CteScan")
+    #  ]),
+    # ("ExecCustomScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("CustomScan")
+    #  ]),
+    # ("ExecForeignScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ForeignScan")
+    #  ]),
+    # ("ExecFunctionScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("FunctionScan")
+    #  ]),
+    # ("ExecGather",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Gather")
+    #  ]),
+    # ("ExecGatherMerge",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("GatherMerge")
+    #  ]),
+    # ("ExecGroup",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Group")
+    #  ]),
+    # ("ExecHashJoinImpl",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("HashJoin")
+    #  ]),
+    # ("ExecIncrementalSort",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("IncrementalSort")
+    #  ]),
+    # ("ExecIndexOnlyScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("IndexOnlyScan")
+    #  ]),
+    # ("ExecIndexScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("IndexScan")
+    #  ]),
+    # ("ExecLimit",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Limit")
+    #  ]),
+    # ("ExecLockRows",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("LockRows")
+    #  ]),
+    # ("ExecMaterial",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Material")
+    #  ]),
+    # ("ExecMergeAppend",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("MergeAppend")
+    #  ]),
+    # ("ExecMergeJoin",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("MergeJoin")
+    #  ]),
+    # ("ExecModifyTable",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ModifyTable")
+    #  ]),
+    # ("ExecNamedTuplestoreScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("NamedTuplestoreScan")
+    #  ]),
+    # ("ExecNestLoop",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("NestLoop")
+    #  ]),
+    # ("ExecProjectSet",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ProjectSet")
+    #  ]),
+    # ("ExecRecursiveUnion",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("RecursiveUnion")
+    #  ]),
+    # ("ExecResult",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Result")
+    #  ]),
+    # ("ExecSampleScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("SampleScan")
+    #  ]),
+    # ("ExecSeqScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Scan")
+    #  ]),
+    # ("ExecSetOp",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("SetOp")
+    #  ]),
+    # ("ExecSort",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Sort")
+    #  ]),
+    # ("ExecSubPlan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecSubqueryScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("SubqueryScan")
+    #  ]),
+    # ("ExecTableFuncScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("TableFuncScan")
+    #  ]),
+    # ("ExecTidScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("TidScan")
+    #  ]),
+    # ("ExecUnique",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Unique")
+    #  ]),
+    # ("ExecValuesScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ValuesScan")
+    #  ]),
+    # ("ExecWindowAgg",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("WindowAgg")
+    #  ]),
+    # ("ExecWorkTableScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("WorkTableScan")
+    #  ]),
 ]
 
 # The metrics to be defined for every OU.

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -116,181 +116,181 @@ OU_DEFS = [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("Agg")
      ]),
-    # ("ExecAppend",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Append")
-    #  ]),
-    # ("ExecCteScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("CteScan")
-    #  ]),
-    # ("ExecCustomScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("CustomScan")
-    #  ]),
-    # ("ExecForeignScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ForeignScan")
-    #  ]),
-    # ("ExecFunctionScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("FunctionScan")
-    #  ]),
-    # ("ExecGather",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Gather")
-    #  ]),
-    # ("ExecGatherMerge",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("GatherMerge")
-    #  ]),
-    # ("ExecGroup",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Group")
-    #  ]),
-    # ("ExecHashJoinImpl",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("HashJoin")
-    #  ]),
-    # ("ExecIncrementalSort",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("IncrementalSort")
-    #  ]),
-    # ("ExecIndexOnlyScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("IndexOnlyScan")
-    #  ]),
-    # ("ExecIndexScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("IndexScan")
-    #  ]),
-    # ("ExecLimit",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Limit")
-    #  ]),
-    # ("ExecLockRows",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("LockRows")
-    #  ]),
-    # ("ExecMaterial",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Material")
-    #  ]),
-    # ("ExecMergeAppend",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("MergeAppend")
-    #  ]),
-    # ("ExecMergeJoin",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("MergeJoin")
-    #  ]),
-    # ("ExecModifyTable",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ModifyTable")
-    #  ]),
-    # ("ExecNamedTuplestoreScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("NamedTuplestoreScan")
-    #  ]),
-    # ("ExecNestLoop",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("NestLoop")
-    #  ]),
-    # ("ExecProjectSet",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ProjectSet")
-    #  ]),
-    # ("ExecRecursiveUnion",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("RecursiveUnion")
-    #  ]),
-    # ("ExecResult",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Result")
-    #  ]),
-    # ("ExecSampleScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("SampleScan")
-    #  ]),
+    ("ExecAppend",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Append")
+     ]),
+    ("ExecCteScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("CteScan")
+     ]),
+    ("ExecCustomScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("CustomScan")
+     ]),
+    ("ExecForeignScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ForeignScan")
+     ]),
+    ("ExecFunctionScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("FunctionScan")
+     ]),
+    ("ExecGather",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Gather")
+     ]),
+    ("ExecGatherMerge",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("GatherMerge")
+     ]),
+    ("ExecGroup",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Group")
+     ]),
+    ("ExecHashJoinImpl",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("HashJoin")
+     ]),
+    ("ExecIncrementalSort",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("IncrementalSort")
+     ]),
+    ("ExecIndexOnlyScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("IndexOnlyScan")
+     ]),
+    ("ExecIndexScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("IndexScan")
+     ]),
+    ("ExecLimit",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Limit")
+     ]),
+    ("ExecLockRows",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("LockRows")
+     ]),
+    ("ExecMaterial",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Material")
+     ]),
+    ("ExecMergeAppend",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("MergeAppend")
+     ]),
+    ("ExecMergeJoin",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("MergeJoin")
+     ]),
+    ("ExecModifyTable",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ModifyTable")
+     ]),
+    ("ExecNamedTuplestoreScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("NamedTuplestoreScan")
+     ]),
+    ("ExecNestLoop",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("NestLoop")
+     ]),
+    ("ExecProjectSet",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ProjectSet")
+     ]),
+    ("ExecRecursiveUnion",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("RecursiveUnion")
+     ]),
+    ("ExecResult",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Result")
+     ]),
+    ("ExecSampleScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("SampleScan")
+     ]),
     ("ExecSeqScan",
      [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("Scan")
      ]),
-    # ("ExecSetOp",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("SetOp")
-    #  ]),
-    # ("ExecSort",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Sort")
-    #  ]),
-    # ("ExecSubPlan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecSubqueryScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("SubqueryScan")
-    #  ]),
-    # ("ExecTableFuncScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("TableFuncScan")
-    #  ]),
-    # ("ExecTidScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("TidScan")
-    #  ]),
-    # ("ExecUnique",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Unique")
-    #  ]),
-    # ("ExecValuesScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ValuesScan")
-    #  ]),
-    # ("ExecWindowAgg",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("WindowAgg")
-    #  ]),
-    # ("ExecWorkTableScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("WorkTableScan")
-    #  ]),
+    ("ExecSetOp",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("SetOp")
+     ]),
+    ("ExecSort",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Sort")
+     ]),
+    ("ExecSubPlan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Plan")
+     ]),
+    ("ExecSubqueryScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("SubqueryScan")
+     ]),
+    ("ExecTableFuncScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("TableFuncScan")
+     ]),
+    ("ExecTidScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("TidScan")
+     ]),
+    ("ExecUnique",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Unique")
+     ]),
+    ("ExecValuesScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ValuesScan")
+     ]),
+    ("ExecWindowAgg",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("WindowAgg")
+     ]),
+    ("ExecWorkTableScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("WorkTableScan")
+     ]),
 ]
 
 # The metrics to be defined for every OU.

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -236,11 +236,11 @@ OU_DEFS = [
     #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
     #      Feature("SampleScan")
     #  ]),
-    # ("ExecSeqScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Scan")
-    #  ]),
+    ("ExecSeqScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Scan")
+     ]),
     # ("ExecSetOp",
     #  [
     #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -217,7 +217,8 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
         def collector_event(cpu, data, size):
             raw_data = collector_bpf[output_buffer].event(data)
             operating_unit = operating_units[raw_data.ou_index]
-            event_features = operating_unit.serialize_features(raw_data)
+            event_features = operating_unit.serialize_features(
+                raw_data)  # TODO(Matt): consider moving serialization to CSV string to Processor
             training_data = ''.join([
                 event_features,
                 ',',

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -101,7 +101,7 @@ def generate_readargs(feature_list):
             readarg_p = ['  bpf_usdt_readarg_p(',
                          f'{idx + non_feature_usdt_args}, ',
                          'ctx, ',
-                         f'&(output->{first_member}), ',
+                         f'&(features->{first_member}), ',
                          f'sizeof(struct DECL_{feature.name})',
                          ');\n']
             code.append(''.join(readarg_p))
@@ -109,7 +109,7 @@ def generate_readargs(feature_list):
             readarg = ['  bpf_usdt_readarg(',
                        f'{idx + non_feature_usdt_args}, ',
                        'ctx, ',
-                       f'&(output->{first_member})',
+                       f'&(features->{first_member})',
                        ');\n']
             code.append(''.join(readarg))
     return ''.join(code)
@@ -160,9 +160,14 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
                   metric.name not in ('start_time', 'end_time', 'cpu_id')]  # don't accumulate these 3 metrics
     metrics_accumulate = ';\n'.join(accumulate) + ';'
     collector_c = collector_c.replace("SUBST_ACCUMULATE", metrics_accumulate)
+    collector_c = collector_c.replace("SUBST_FIRST_FEATURE", ou.features_list[0].bpf_tuple[0].name)
+    collector_c = collector_c.replace("SUBST_FIRST_METRIC", metrics[0].name)
 
     num_cpus = len(utils.get_online_cpus())
     collector_c = collector_c.replace("MAX_CPUS", str(num_cpus))
+
+    print(collector_c)
+    exit()
 
     # Attach USDT probes to the target PID.
     collector_probes = USDT(pid=pid)

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -169,8 +169,7 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     # Attach USDT probes to the target PID.
     collector_probes = USDT(pid=pid)
     for ou in operating_units:
-        for probe in [ou.begin_marker(), ou.end_marker(),
-                      ou.features_marker()]:
+        for probe in [ou.features_marker(), ou.begin_marker(), ou.end_marker(), ou.flush_marker()]:
             collector_probes.enable_probe(probe=probe, fn_name=probe)
 
     # Load the BPF program, eliding setting the socket fd

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -166,9 +166,6 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     num_cpus = len(utils.get_online_cpus())
     collector_c = collector_c.replace("MAX_CPUS", str(num_cpus))
 
-    print(collector_c)
-    exit()
-
     # Attach USDT probes to the target PID.
     collector_probes = USDT(pid=pid)
     for ou in operating_units:

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -3276,6 +3276,9 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
 	bool		use_hashing = (node->aggstrategy == AGG_HASHED ||
 							   node->aggstrategy == AGG_MIXED);
 
+    TS_MARKER(ExecAgg_features, node->plan.plan_node_id,
+                estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -4381,9 +4384,6 @@ ExecEndAgg(AggState *node)
 	int			transno;
 	int			numGroupingSets = Max(node->maxsets, 1);
 	int			setno;
-
-        TS_MARKER(ExecAgg_features, node->ss.ps.plan->plan_node_id,
-                  node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * When ending a parallel worker, copy the statistics gathered by the

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -4385,6 +4385,8 @@ ExecEndAgg(AggState *node)
 	int			numGroupingSets = Max(node->maxsets, 1);
 	int			setno;
 
+        TS_MARKER(ExecAgg_flush, node->ss.ps.plan->plan_node_id);
+
 	/*
 	 * When ending a parallel worker, copy the statistics gathered by the
 	 * worker back into shared memory so that it can be picked up by the main

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -119,6 +119,9 @@ ExecInitAppend(Append *node, EState *estate, int eflags)
 	int			i,
 				j;
 
+        TS_MARKER(ExecAppend_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));
 
@@ -400,8 +403,7 @@ ExecEndAppend(AppendState *node)
 	int			nplans;
 	int			i;
 
-        TS_MARKER(ExecAppend_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecAppend_flush, node->ps.plan->plan_node_id);
 
 	/*
 	 * get information from the node

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -179,6 +179,9 @@ ExecInitCteScan(CteScan *node, EState *estate, int eflags)
 	CteScanState *scanstate;
 	ParamExecData *prmdata;
 
+        TS_MARKER(ExecCteScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));
 
@@ -290,8 +293,7 @@ void
 ExecEndCteScan(CteScanState *node)
 {
 
-        TS_MARKER(ExecCteScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecCteScan_flush, node->ss.ps.plan->plan_node_id);
 
 	/*
 	 * Free exprcontext

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -34,6 +34,9 @@ ExecInitCustomScan(CustomScan *cscan, EState *estate, int eflags)
 	Index		scanrelid = cscan->scan.scanrelid;
 	Index		tlistvarno;
 
+        TS_MARKER(ExecCustomScan_features, cscan->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, cscan);
+
 	/*
 	 * Allocate the CustomScanState object.  We let the custom scan provider
 	 * do the palloc, in case it wants to make a larger object that embeds
@@ -121,9 +124,7 @@ TS_EXECUTOR_WRAPPER(CustomScan)
 void
 ExecEndCustomScan(CustomScanState *node)
 {
-
-        TS_MARKER(ExecCustomScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecCustomScan_flush, node->ss.ps.plan->plan_node_id);
 
 	Assert(node->methods->EndCustomScan != NULL);
 	node->methods->EndCustomScan(node);

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -143,6 +143,9 @@ ExecInitForeignScan(ForeignScan *node, EState *estate, int eflags)
 	Index		tlistvarno;
 	FdwRoutine *fdwroutine;
 
+        TS_MARKER(ExecForeignScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -292,8 +295,7 @@ ExecEndForeignScan(ForeignScanState *node)
 	ForeignScan *plan = (ForeignScan *) node->ss.ps.plan;
 	EState	   *estate = node->ss.ps.state;
 
-        TS_MARKER(ExecForeignScan_features, node->ss.ps.plan->plan_node_id,
-                  node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecForeignScan_flush, node->ss.ps.plan->plan_node_id);
 
 	/* Let the FDW shut down */
 	if (plan->operation != CMD_SELECT)

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -289,6 +289,9 @@ ExecInitFunctionScan(FunctionScan *node, EState *estate, int eflags)
 				natts;
 	ListCell   *lc;
 
+        TS_MARKER(ExecFunctionScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));
 
@@ -526,8 +529,7 @@ ExecEndFunctionScan(FunctionScanState *node)
 {
 	int			i;
 
-        TS_MARKER(ExecFunctionScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecFunctionScan_flush, node->ss.ps.plan->plan_node_id);
 
 	/*
 	 * Free the exprcontext

--- a/src/backend/executor/nodeGather.c
+++ b/src/backend/executor/nodeGather.c
@@ -62,6 +62,9 @@ ExecInitGather(Gather *node, EState *estate, int eflags)
 	Plan	   *outerNode;
 	TupleDesc	tupDesc;
 
+        TS_MARKER(ExecGather_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* Gather node doesn't have innerPlan node. */
 	Assert(innerPlan(node) == NULL);
 
@@ -251,8 +254,7 @@ TS_EXECUTOR_WRAPPER(Gather)
 void
 ExecEndGather(GatherState *node)
 {
-        TS_MARKER(ExecGather_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecGather_flush, node->ps.plan->plan_node_id);
 	ExecEndNode(outerPlanState(node));	/* let children clean up first */
 	ExecShutdownGather(node);
 	ExecFreeExprContext(&node->ps);

--- a/src/backend/executor/nodeGatherMerge.c
+++ b/src/backend/executor/nodeGatherMerge.c
@@ -76,6 +76,9 @@ ExecInitGatherMerge(GatherMerge *node, EState *estate, int eflags)
 	Plan	   *outerNode;
 	TupleDesc	tupDesc;
 
+        TS_MARKER(ExecGatherMerge_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* Gather merge node doesn't have innerPlan node. */
 	Assert(innerPlan(node) == NULL);
 
@@ -291,8 +294,7 @@ TS_EXECUTOR_WRAPPER(GatherMerge)
 void
 ExecEndGatherMerge(GatherMergeState *node)
 {
-        TS_MARKER(ExecGatherMerge_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecGatherMerge_flush, node->ps.plan->plan_node_id);
 	ExecEndNode(outerPlanState(node));	/* let children clean up first */
 	ExecShutdownGatherMerge(node);
 	ExecFreeExprContext(&node->ps);

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -167,6 +167,9 @@ ExecInitGroup(Group *node, EState *estate, int eflags)
 	GroupState *grpstate;
 	const TupleTableSlotOps *tts_ops;
 
+        TS_MARKER(ExecGroup_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -231,7 +234,7 @@ ExecEndGroup(GroupState *node)
 {
 	PlanState  *outerPlan;
 
-        TS_MARKER(ExecGroup_features, node->ss.ps.plan->plan_node_id,
+        TS_MARKER(ExecGroup_flush, node->ss.ps.plan->plan_node_id,
             node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	ExecFreeExprContext(&node->ss.ps);

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -583,8 +583,7 @@ ExecHashJoinImpl(PlanState *pstate, bool parallel) {
 
   result = WrappedExecHashJoinImpl(pstate, parallel);
 
-  TS_MARKER(ExecHashJoinImpl_end, TupIsNull(result),
-            pstate->plan->plan_node_id);
+  TS_MARKER(ExecHashJoinImpl_end, pstate->plan->plan_node_id);
 
   return result;
 }
@@ -636,6 +635,9 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
 	TupleDesc	outerDesc,
 				innerDesc;
 	const TupleTableSlotOps *ops;
+
+        TS_MARKER(ExecHashJoinImpl_features, node->join.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
@@ -778,9 +780,7 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
 void
 ExecEndHashJoin(HashJoinState *node)
 {
-
-        TS_MARKER(ExecHashJoinImpl_features, node->js.ps.plan->plan_node_id,
-            node->js.ps.state->es_plannedstmt->queryId, node->js.ps.plan);
+        TS_MARKER(ExecHashJoinImpl_flush, node->js.ps.plan->plan_node_id);
 
         /*
 	 * Free hash table

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -583,7 +583,8 @@ ExecHashJoinImpl(PlanState *pstate, bool parallel) {
 
   result = WrappedExecHashJoinImpl(pstate, parallel);
 
-  TS_MARKER(ExecHashJoinImpl_end, pstate->plan->plan_node_id);
+  TS_MARKER(ExecHashJoinImpl_end, TupIsNull(result),
+            pstate->plan->plan_node_id);
 
   return result;
 }

--- a/src/backend/executor/nodeIncrementalSort.c
+++ b/src/backend/executor/nodeIncrementalSort.c
@@ -979,6 +979,9 @@ ExecInitIncrementalSort(IncrementalSort *node, EState *estate, int eflags)
 {
 	IncrementalSortState *incrsortstate;
 
+        TS_MARKER(ExecIncrementalSort_features, node->sort.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	SO_printf("ExecInitIncrementalSort: initializing sort node\n");
 
 	/*
@@ -1078,8 +1081,7 @@ ExecInitIncrementalSort(IncrementalSort *node, EState *estate, int eflags)
 void
 ExecEndIncrementalSort(IncrementalSortState *node)
 {
-        TS_MARKER(ExecIncrementalSort_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecIncrementalSort_flush, node->ss.ps.plan->plan_node_id);
 	SO_printf("ExecEndIncrementalSort: shutting down sort node\n");
 
 	/* clean out the scan tuple */

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -374,8 +374,7 @@ ExecEndIndexOnlyScan(IndexOnlyScanState *node)
 	Relation	indexRelationDesc;
 	IndexScanDesc indexScanDesc;
 
-        TS_MARKER(ExecIndexOnlyScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecIndexOnlyScan_flush, node->ss.ps.plan->plan_node_id);
 
 	/*
 	 * extract information from the node
@@ -502,6 +501,9 @@ ExecInitIndexOnlyScan(IndexOnlyScan *node, EState *estate, int eflags)
 	Relation	currentRelation;
 	LOCKMODE	lockmode;
 	TupleDesc	tupDesc;
+
+        TS_MARKER(ExecIndexOnlyScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
 
 	/*
 	 * create state structure

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -788,8 +788,7 @@ ExecEndIndexScan(IndexScanState *node)
 	Relation	indexRelationDesc;
 	IndexScanDesc indexScanDesc;
 
-        TS_MARKER(ExecIndexScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecIndexScan_flush, node->ss.ps.plan->plan_node_id);
 
 	/*
 	 * extract information from the node
@@ -908,6 +907,9 @@ ExecInitIndexScan(IndexScan *node, EState *estate, int eflags)
 	IndexScanState *indexstate;
 	Relation	currentRelation;
 	LOCKMODE	lockmode;
+
+        TS_MARKER(ExecIndexScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
 
 	/*
 	 * create state structure

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -360,8 +360,7 @@ recompute_limits(LimitState *node)
 	Datum		val;
 	bool		isNull;
 
-        TS_MARKER(ExecLimit_features, node->ps.plan->plan_node_id,
-                  node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecLimit_flush, node->ps.plan->plan_node_id);
 
 	if (node->limitOffset)
 	{
@@ -455,6 +454,9 @@ ExecInitLimit(Limit *node, EState *estate, int eflags)
 {
 	LimitState *limitstate;
 	Plan	   *outerPlan;
+
+        TS_MARKER(ExecLimit_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -299,6 +299,9 @@ ExecInitLockRows(LockRows *node, EState *estate, int eflags)
 	List	   *epq_arowmarks;
 	ListCell   *lc;
 
+        TS_MARKER(ExecLockRows_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));
 
@@ -388,8 +391,7 @@ ExecInitLockRows(LockRows *node, EState *estate, int eflags)
 void
 ExecEndLockRows(LockRowsState *node)
 {
-        TS_MARKER(ExecLockRows_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecLockRows_flush, node->ps.plan->plan_node_id);
 
 	/* We may have shut down EPQ already, but no harm in another call */
 	EvalPlanQualEnd(&node->lr_epqstate);

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -169,6 +169,9 @@ ExecInitMaterial(Material *node, EState *estate, int eflags)
 	MaterialState *matstate;
 	Plan	   *outerPlan;
 
+        TS_MARKER(ExecMaterial_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/*
 	 * create state structure
 	 */
@@ -242,8 +245,7 @@ ExecInitMaterial(Material *node, EState *estate, int eflags)
 void
 ExecEndMaterial(MaterialState *node)
 {
-        TS_MARKER(ExecMaterial_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecMaterial_flush, node->ss.ps.plan->plan_node_id);
 
 	/*
 	 * clean out the tuple table

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -72,6 +72,9 @@ ExecInitMergeAppend(MergeAppend *node, EState *estate, int eflags)
 	int			i,
 				j;
 
+        TS_MARKER(ExecMergeAppend_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -338,8 +341,7 @@ ExecEndMergeAppend(MergeAppendState *node)
 	int			nplans;
 	int			i;
 
-        TS_MARKER(ExecMergeAppend_features, node->ps.plan->plan_node_id,
-                  node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecMergeAppend_flush, node->ps.plan->plan_node_id);
 
 	/*
 	 * get information from the node

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1443,6 +1443,9 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 				innerDesc;
 	const TupleTableSlotOps *innerOps;
 
+        TS_MARKER(ExecMergeJoin_features, node->join.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -1634,8 +1637,7 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 void
 ExecEndMergeJoin(MergeJoinState *node)
 {
-        TS_MARKER(ExecMergeJoin_features, node->js.ps.plan->plan_node_id,
-            node->js.ps.state->es_plannedstmt->queryId, node->js.ps.plan);
+        TS_MARKER(ExecMergeJoin_flush, node->js.ps.plan->plan_node_id);
 
 	MJ1_printf("ExecEndMergeJoin: %s\n",
 			   "ending node processing");

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2720,6 +2720,9 @@ ExecInitModifyTable(ModifyTable *node, EState *estate, int eflags)
 	int			i;
 	Relation	rel;
 
+        TS_MARKER(ExecModifyTable_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -3173,8 +3176,7 @@ ExecEndModifyTable(ModifyTableState *node)
 {
 	int			i;
 
-        TS_MARKER(ExecModifyTable_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecModifyTable_flush, node->ps.plan->plan_node_id);
 
 	/*
 	 * Allow any FDWs to shut down

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -87,6 +87,9 @@ ExecInitNamedTuplestoreScan(NamedTuplestoreScan *node, EState *estate, int eflag
 	NamedTuplestoreScanState *scanstate;
 	EphemeralNamedRelation enr;
 
+        TS_MARKER(ExecNamedTuplestoreScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -166,8 +169,7 @@ ExecInitNamedTuplestoreScan(NamedTuplestoreScan *node, EState *estate, int eflag
 void
 ExecEndNamedTuplestoreScan(NamedTuplestoreScanState *node)
 {
-        TS_MARKER(ExecNamedTuplestoreScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecNamedTuplestoreScan_flush, node->ss.ps.plan->plan_node_id);
 
 	/*
 	 * Free exprcontext

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -267,6 +267,9 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 {
 	NestLoopState *nlstate;
 
+        TS_MARKER(ExecNestLoop_features, node->join.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -364,8 +367,7 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 void
 ExecEndNestLoop(NestLoopState *node)
 {
-        TS_MARKER(ExecNestLoop_features, node->js.ps.plan->plan_node_id,
-            node->js.ps.state->es_plannedstmt->queryId, node->js.ps.plan);
+        TS_MARKER(ExecNestLoop_flush, node->js.ps.plan->plan_node_id);
 
 	NL1_printf("ExecEndNestLoop: %s\n",
 			   "ending node processing");

--- a/src/backend/executor/nodeProjectSet.c
+++ b/src/backend/executor/nodeProjectSet.c
@@ -226,6 +226,9 @@ ExecInitProjectSet(ProjectSet *node, EState *estate, int eflags)
 	ListCell   *lc;
 	int			off;
 
+        TS_MARKER(ExecProjectSet_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_MARK | EXEC_FLAG_BACKWARD)));
 
@@ -323,8 +326,7 @@ ExecInitProjectSet(ProjectSet *node, EState *estate, int eflags)
 void
 ExecEndProjectSet(ProjectSetState *node)
 {
-        TS_MARKER(ExecProjectSet_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecProjectSet_flush, node->ps.plan->plan_node_id);
 
 	/*
 	 * Free the exprcontext

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -172,6 +172,9 @@ ExecInitRecursiveUnion(RecursiveUnion *node, EState *estate, int eflags)
 	RecursiveUnionState *rustate;
 	ParamExecData *prmdata;
 
+        TS_MARKER(ExecRecursiveUnion_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -274,8 +277,7 @@ ExecInitRecursiveUnion(RecursiveUnion *node, EState *estate, int eflags)
 void
 ExecEndRecursiveUnion(RecursiveUnionState *node)
 {
-        TS_MARKER(ExecRecursiveUnion_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecRecursiveUnion_flush, node->ps.plan->plan_node_id);
 
 	/* Release tuplestores */
 	tuplestore_end(node->working_table);

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -185,6 +185,9 @@ ExecInitResult(Result *node, EState *estate, int eflags)
 {
 	ResultState *resstate;
 
+        TS_MARKER(ExecResult_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_MARK | EXEC_FLAG_BACKWARD)) ||
 		   outerPlan(node) != NULL);
@@ -243,8 +246,7 @@ ExecInitResult(Result *node, EState *estate, int eflags)
 void
 ExecEndResult(ResultState *node)
 {
-        TS_MARKER(ExecResult_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecResult_flush, node->ps.plan->plan_node_id);
 
 	/*
 	 * Free the exprcontext

--- a/src/backend/executor/nodeSamplescan.c
+++ b/src/backend/executor/nodeSamplescan.c
@@ -102,6 +102,9 @@ ExecInitSampleScan(SampleScan *node, EState *estate, int eflags)
 	TableSampleClause *tsc = node->tablesample;
 	TsmRoutine *tsm;
 
+        TS_MARKER(ExecSampleScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	Assert(outerPlan(node) == NULL);
 	Assert(innerPlan(node) == NULL);
 
@@ -184,8 +187,7 @@ ExecInitSampleScan(SampleScan *node, EState *estate, int eflags)
 void
 ExecEndSampleScan(SampleScanState *node)
 {
-        TS_MARKER(ExecSampleScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecSampleScan_flush, node->ss.ps.plan->plan_node_id);
 
 	/*
 	 * Tell sampling function that we finished the scan.

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -126,6 +126,9 @@ ExecInitSeqScan(SeqScan *node, EState *estate, int eflags)
 {
 	SeqScanState *scanstate;
 
+        TS_MARKER(ExecSeqScan_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/*
 	 * Once upon a time it was possible to have an outerPlan of a SeqScan, but
 	 * not any more.
@@ -186,9 +189,6 @@ void
 ExecEndSeqScan(SeqScanState *node)
 {
 	TableScanDesc scanDesc;
-
-        TS_MARKER(ExecSeqScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
 
 	/*
 	 * get information from node

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -190,6 +190,8 @@ ExecEndSeqScan(SeqScanState *node)
 {
 	TableScanDesc scanDesc;
 
+        TS_MARKER(ExecSeqScan_flush, node->ss.ps.plan->plan_node_id);
+
 	/*
 	 * get information from node
 	 */

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -486,6 +486,9 @@ ExecInitSetOp(SetOp *node, EState *estate, int eflags)
 	SetOpState *setopstate;
 	TupleDesc	outerDesc;
 
+        TS_MARKER(ExecSetOp_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -585,8 +588,7 @@ ExecInitSetOp(SetOp *node, EState *estate, int eflags)
 void
 ExecEndSetOp(SetOpState *node)
 {
-        TS_MARKER(ExecSetOp_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecSetOp_flush, node->ps.plan->plan_node_id);
 
 	/* clean up tuple table */
 	ExecClearTuple(node->ps.ps_ResultTupleSlot);

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -171,6 +171,9 @@ ExecInitSort(Sort *node, EState *estate, int eflags)
 {
 	SortState  *sortstate;
 
+        TS_MARKER(ExecSort_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	SO1_printf("ExecInitSort: %s\n",
 			   "initializing sort node");
 
@@ -237,8 +240,7 @@ ExecInitSort(Sort *node, EState *estate, int eflags)
 void
 ExecEndSort(SortState *node)
 {
-        TS_MARKER(ExecSort_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecSort_flush, node->ss.ps.plan->plan_node_id);
 
 	SO1_printf("ExecEndSort: %s\n",
 			   "shutting down sort node");

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -104,15 +104,16 @@ Datum pg_attribute_always_inline ExecSubPlan(SubPlanState *node,
                                              ExprContext *econtext,
                                              bool *isNull) {
   Datum result;
+  TS_MARKER(ExecSubPlan_features, node->planstate->plan->plan_node_id,
+            node->planstate->state->es_plannedstmt->queryId,
+            node->planstate->plan);
   TS_MARKER(ExecSubPlan_begin, node->planstate->plan->plan_node_id);
 
   result = WrappedExecSubPlan(node, econtext, isNull);
 
   TS_MARKER(ExecSubPlan_end, true, node->planstate->plan->plan_node_id);
   // TODO(Matt): Can't actually find a better place for this FEATURES Marker
-  TS_MARKER(ExecSubPlan_features, node->planstate->plan->plan_node_id,
-            node->planstate->state->es_plannedstmt->queryId,
-            node->planstate->plan);
+  TS_MARKER(ExecSubPlan_flush, node->planstate->plan->plan_node_id);
 
   return result;
 }

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -108,7 +108,7 @@ Datum pg_attribute_always_inline ExecSubPlan(SubPlanState *node,
 
   result = WrappedExecSubPlan(node, econtext, isNull);
 
-  TS_MARKER(ExecSubPlan_end, node->planstate->plan->plan_node_id);
+  TS_MARKER(ExecSubPlan_end, true, node->planstate->plan->plan_node_id);
   // TODO(Matt): Can't actually find a better place for this FEATURES Marker
   TS_MARKER(ExecSubPlan_features, node->planstate->plan->plan_node_id,
             node->planstate->state->es_plannedstmt->queryId,

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -112,7 +112,6 @@ Datum pg_attribute_always_inline ExecSubPlan(SubPlanState *node,
   result = WrappedExecSubPlan(node, econtext, isNull);
 
   TS_MARKER(ExecSubPlan_end, true, node->planstate->plan->plan_node_id);
-  // TODO(Matt): Can't actually find a better place for this FEATURES Marker
   TS_MARKER(ExecSubPlan_flush, node->planstate->plan->plan_node_id);
 
   return result;

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -101,6 +101,9 @@ ExecInitSubqueryScan(SubqueryScan *node, EState *estate, int eflags)
 {
 	SubqueryScanState *subquerystate;
 
+        TS_MARKER(ExecSubqueryScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));
 
@@ -170,8 +173,7 @@ ExecInitSubqueryScan(SubqueryScan *node, EState *estate, int eflags)
 void
 ExecEndSubqueryScan(SubqueryScanState *node)
 {
-        TS_MARKER(ExecSubqueryScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecSubqueryScan_flush, node->ss.ps.plan->plan_node_id);
 
 	/*
 	 * Free the exprcontext

--- a/src/backend/executor/nodeTableFuncscan.c
+++ b/src/backend/executor/nodeTableFuncscan.c
@@ -117,6 +117,9 @@ ExecInitTableFuncScan(TableFuncScan *node, EState *estate, int eflags)
 	TupleDesc	tupdesc;
 	int			i;
 
+        TS_MARKER(ExecTableFuncScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));
 
@@ -216,8 +219,7 @@ ExecInitTableFuncScan(TableFuncScan *node, EState *estate, int eflags)
 void
 ExecEndTableFuncScan(TableFuncScanState *node)
 {
-      TS_MARKER(ExecTableFuncScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+      TS_MARKER(ExecTableFuncScan_flush, node->ss.ps.plan->plan_node_id);
 	/*
 	 * Free the exprcontext
 	 */

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -470,8 +470,7 @@ ExecReScanTidScan(TidScanState *node)
 void
 ExecEndTidScan(TidScanState *node)
 {
-        TS_MARKER(ExecTidScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecTidScan_flush, node->ss.ps.plan->plan_node_id);
 
 	if (node->ss.ss_currentScanDesc)
 		table_endscan(node->ss.ss_currentScanDesc);
@@ -505,6 +504,9 @@ ExecInitTidScan(TidScan *node, EState *estate, int eflags)
 {
 	TidScanState *tidstate;
 	Relation	currentRelation;
+        
+        TS_MARKER(ExecTidScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
 
 	/*
 	 * create state structure

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -119,6 +119,9 @@ ExecInitUnique(Unique *node, EState *estate, int eflags)
 {
 	UniqueState *uniquestate;
 
+        TS_MARKER(ExecUnique_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -171,8 +174,7 @@ ExecInitUnique(Unique *node, EState *estate, int eflags)
 void
 ExecEndUnique(UniqueState *node)
 {
-        TS_MARKER(ExecUnique_features, node->ps.plan->plan_node_id,
-            node->ps.state->es_plannedstmt->queryId, node->ps.plan);
+        TS_MARKER(ExecUnique_flush, node->ps.plan->plan_node_id);
 
 	/* clean up tuple table */
 	ExecClearTuple(node->ps.ps_ResultTupleSlot);

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -219,6 +219,9 @@ ExecInitValuesScan(ValuesScan *node, EState *estate, int eflags)
 	int			i;
 	PlanState  *planstate;
 
+        TS_MARKER(ExecValuesScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/*
 	 * ValuesScan should not have any children.
 	 */
@@ -331,8 +334,7 @@ ExecInitValuesScan(ValuesScan *node, EState *estate, int eflags)
 void
 ExecEndValuesScan(ValuesScanState *node)
 {
-      TS_MARKER(ExecValuesScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecValuesScan_flush, node->ss.ps.plan->plan_node_id);
 
 	/*
 	 * Free both exprcontexts

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -2265,6 +2265,9 @@ ExecInitWindowAgg(WindowAgg *node, EState *estate, int eflags)
 	TupleDesc	scanDesc;
 	ListCell   *l;
 
+        TS_MARKER(ExecWindowAgg_features, node->plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -2538,8 +2541,7 @@ ExecEndWindowAgg(WindowAggState *node)
 	PlanState  *outerPlan;
 	int			i;
 
-        TS_MARKER(ExecWindowAgg_features, node->ss.ps.plan->plan_node_id,
-                  node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecWindowAgg_flush, node->ss.ps.plan->plan_node_id);
 
 	release_partition(node);
 

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -133,6 +133,9 @@ ExecInitWorkTableScan(WorkTableScan *node, EState *estate, int eflags)
 {
 	WorkTableScanState *scanstate;
 
+        TS_MARKER(ExecWorkTableScan_features, node->scan.plan.plan_node_id,
+                  estate->es_plannedstmt->queryId, node);
+
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));
 
@@ -192,8 +195,7 @@ ExecInitWorkTableScan(WorkTableScan *node, EState *estate, int eflags)
 void
 ExecEndWorkTableScan(WorkTableScanState *node)
 {
-        TS_MARKER(ExecWorkTableScan_features, node->ss.ps.plan->plan_node_id,
-            node->ss.ps.state->es_plannedstmt->queryId, node->ss.ps.plan);
+        TS_MARKER(ExecWorkTableScan_flush, node->ss.ps.plan->plan_node_id);
 	/*
 	 * Free exprcontext
 	 */

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -21,6 +21,7 @@
                                                                                \
     result = WrappedExec##node_type(pstate);                                   \
                                                                                \
-    TS_MARKER(Exec##node_type##_end, pstate->plan->plan_node_id);              \
+    TS_MARKER(Exec##node_type##_end, TupIsNull(result),                        \
+              pstate->plan->plan_node_id);                                     \
     return result;                                                             \
   }

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -21,7 +21,6 @@
                                                                                \
     result = WrappedExec##node_type(pstate);                                   \
                                                                                \
-    TS_MARKER(Exec##node_type##_end, TupIsNull(result),                        \
-              pstate->plan->plan_node_id);                                     \
+    TS_MARKER(Exec##node_type##_end, pstate->plan->plan_node_id);              \
     return result;                                                             \
   }


### PR DESCRIPTION
In an effort to make capturing valid features easier (only stuff you know _a priori_, without execution, and potentially in another scope than the execution itself) the Features Marker now lives ahead of Begin/End. For this to happen, I added another BPF map to stash complete features that are waiting for their corresponding resource metrics. A side effect of this change is that we now need a Flush marker for OUs that accumulate metrics with multiple Begin/End cycles. Before we could rely on the Features marker as the indication that we were done collecting metrics for that data point. I tried adding a `flush` argument to the End marker, and while this works, the predicate is potentially different for every OU and the consequence of getting it wrong is non-obvious. You'd just get bad data, rather than no data. This way, a Flush marker has to be explicitly placed or no data will be generated. This has an overhead cost, but we believe is worth the engineering simplicity.