### PR TITLE
Tag the first field of an unrolled struct with the struct's alignment

### DIFF
--- a/cmudb/tscout/clang_parser.py
+++ b/cmudb/tscout/clang_parser.py
@@ -70,6 +70,13 @@ class Field:
     canonical_type_kind: clang.cindex.TypeKind
 
 
+@dataclass
+class StructInfo:
+    """Value type of the ClangParser struct_map. Stash any metadata that we need about original parsed structs here."""
+    fields: List[Field]
+    alignment: int
+
+
 class ClangParser:
     """
     On init, ClangParser parses the PostgreSQL source code to construct a
@@ -78,7 +85,7 @@ class ClangParser:
 
     Attributes
     ----------
-    field_map : Mapping[str, List[Field]]
+    struct_map : Mapping[str, StructInfo]
         Maps from (struct name) to a (base-class- and record-type-
         expanded list of all fields for the struct).
     """
@@ -125,14 +132,14 @@ class ClangParser:
         #       but base classes not expanded, record types not expanded.
         # 4. _rtti_map
         #       _fields with base classes expanded.
-        # 5. field_map
-        #       _fields with base classes expanded and record types expanded.
+        # 5. struct_map
+        #       _fields with base classes expanded and record types expanded, and original struct alignment info.
 
         # _classes : list of all classes in the translation unit
         self._classes: List[clang.cindex.Cursor] = classes.values()
         self._classes = sorted(self._classes, key=lambda node: node.spelling)
 
-        # _bases : class name -> list of base classes for the class
+        # _bases : class name -> list of base classes for the class, for C++ inheritance.
         self._bases: Mapping[str, List[clang.cindex.Cursor]] = {
             node.spelling: [
                 child.referenced
@@ -157,7 +164,7 @@ class ClangParser:
         }
 
         # _rtti_map : class name ->
-        #               list of fields in the class with base classes expanded
+        #               list of fields in the class with base classes expanded, for C++ inheritance.
         self._rtti_map: Mapping[str, List[Field]] = {
             node_name: self._construct_base_expanded_fields(node_name)
             for node_name in self._bases
@@ -166,12 +173,14 @@ class ClangParser:
         # field_map: class name ->
         #               list of fields in the class with base classes expanded
         #               and record types expanded
-        self.field_map: Mapping[str, List[Field]] = {
+        self.struct_map: Mapping[str, StructInfo] = {
             node_name:
-                self._construct_fully_expanded_fields(
-                    node_name,
-                    prefix=f'{node_name}_'
-                )
+                StructInfo(
+                    fields=self._construct_fully_expanded_fields(
+                        node_name,
+                        prefix=f'{node_name}_'
+                    ),
+                    alignment=classes[node_name].type.get_align())
             for node_name in self._bases
         }
 

--- a/cmudb/tscout/clang_parser.py
+++ b/cmudb/tscout/clang_parser.py
@@ -236,14 +236,13 @@ class ClangParser:
         fields = rtti_map[class_name]
         new_fields = []
         # For every field in the base-class-expanded field list for the class,
-        for i, field in enumerate(fields):
+        for field in fields:
             if field.canonical_type_kind != clang.cindex.TypeKind.RECORD:
                 # If the field is not a record type,
                 # just append the field to the list of new fields.
                 new_field = Field(name=f'{prefix}{field.name}',
                                   pg_type=field.pg_type,
-                                  canonical_type_kind=field.canonical_type_kind,
-                                  alignment=classes[class_name].type.get_align() if i == 0 else None)
+                                  canonical_type_kind=field.canonical_type_kind)
                 new_fields.append(new_field)
             else:
                 # If the field is a record type, try adding the list of
@@ -259,4 +258,7 @@ class ClangParser:
                         classes,
                         prefix=prefix + f'{field.name}_')
                     new_fields.extend(expanded_fields)
+        new_fields[0].alignment = classes[class_name].type.get_align()
+        # The alignment value is the struct's alignment, not the field. We assign this to the first field of a
+        # struct since the address of a struct and its first field must be the same.
         return new_fields

--- a/cmudb/tscout/clang_parser.py
+++ b/cmudb/tscout/clang_parser.py
@@ -68,7 +68,7 @@ class Field:
     name: str
     pg_type: str
     canonical_type_kind: clang.cindex.TypeKind
-    alignment: int = None
+    alignment: int = None  # Non-None for the first field of a struct, using alignment value of the struct.
 
 
 class ClangParser:
@@ -260,5 +260,6 @@ class ClangParser:
                     new_fields.extend(expanded_fields)
         new_fields[0].alignment = classes[class_name].type.get_align()
         # The alignment value is the struct's alignment, not the field. We assign this to the first field of a
-        # struct since the address of a struct and its first field must be the same.
+        # struct since the address of a struct and its first field must be the same since their memory addresses must be
+        # the same.
         return new_fields

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -4,9 +4,9 @@ struct SUBST_OU_features {
 };
 
 struct SUBST_OU_output {
+  u32 ou_index;
   SUBST_FEATURES;  // Replaced by a list of the features for this subsystem
   SUBST_METRICS;   // Replaced by the list of metrics
-  u32 ou_index;
 };
 
 // Stores features for a training data point, waiting for BEGIN, END, and FLUSH.

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -4,9 +4,9 @@ struct SUBST_OU_features {
 };
 
 struct SUBST_OU_output {
-  u32 ou_index;
   SUBST_FEATURES;  // Replaced by a list of the features for this subsystem
   SUBST_METRICS;   // Replaced by the list of metrics
+  u32 ou_index;    // TODO(Matt): DOCUMENT THIS IN THE PADDING ASSUMPTION
 };
 
 // Stores features for a training data point, waiting for BEGIN, END, and FLUSH.

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -6,7 +6,7 @@ struct SUBST_OU_features {
 struct SUBST_OU_output {
   SUBST_FEATURES;  // Replaced by a list of the features for this subsystem
   SUBST_METRICS;   // Replaced by the list of metrics
-  u32 ou_index;    // TODO(Matt): DOCUMENT THIS IN THE PADDING ASSUMPTION
+  u32 ou_index;
 };
 
 // Stores features for a training data point, waiting for BEGIN, END, and FLUSH.

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -77,7 +77,15 @@ class BPFVariable:
         elif self.c_type == clang.cindex.TypeKind.DOUBLE:
             return str(struct.unpack('d', getattr(output_event, self.name).to_bytes(8, byteorder=sys.byteorder))[0])
         else:
-            return str(getattr(output_event, self.name))
+            print(dir(output_event))
+            string_value = None
+            try:
+                string_value = str(getattr(output_event, self.name))
+            except AttributeError as e:
+                print(self.name)
+                print(output_event)
+                exit()
+            return
 
 
 @dataclass
@@ -118,181 +126,181 @@ OU_DEFS = [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("Agg")
      ]),
-    ("ExecAppend",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Append")
-     ]),
-    ("ExecCteScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("CteScan")
-     ]),
-    ("ExecCustomScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("CustomScan")
-     ]),
-    ("ExecForeignScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ForeignScan")
-     ]),
-    ("ExecFunctionScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("FunctionScan")
-     ]),
-    ("ExecGather",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Gather")
-     ]),
-    ("ExecGatherMerge",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("GatherMerge")
-     ]),
-    ("ExecGroup",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Group")
-     ]),
-    ("ExecHashJoinImpl",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("HashJoin")
-     ]),
-    ("ExecIncrementalSort",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IncrementalSort")
-     ]),
-    ("ExecIndexOnlyScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IndexOnlyScan")
-     ]),
-    ("ExecIndexScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IndexScan")
-     ]),
-    ("ExecLimit",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Limit")
-     ]),
-    ("ExecLockRows",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("LockRows")
-     ]),
-    ("ExecMaterial",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Material")
-     ]),
-    ("ExecMergeAppend",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MergeAppend")
-     ]),
-    ("ExecMergeJoin",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MergeJoin")
-     ]),
-    ("ExecModifyTable",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ModifyTable")
-     ]),
-    ("ExecNamedTuplestoreScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("NamedTuplestoreScan")
-     ]),
-    ("ExecNestLoop",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("NestLoop")
-     ]),
-    ("ExecProjectSet",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ProjectSet")
-     ]),
-    ("ExecRecursiveUnion",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("RecursiveUnion")
-     ]),
-    ("ExecResult",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Result")
-     ]),
-    ("ExecSampleScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SampleScan")
-     ]),
-    ("ExecSeqScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Scan")
-     ]),
-    ("ExecSetOp",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SetOp")
-     ]),
-    ("ExecSort",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Sort")
-     ]),
-    ("ExecSubPlan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Plan")
-     ]),
-    ("ExecSubqueryScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SubqueryScan")
-     ]),
-    ("ExecTableFuncScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("TableFuncScan")
-     ]),
-    ("ExecTidScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("TidScan")
-     ]),
-    ("ExecUnique",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Unique")
-     ]),
-    ("ExecValuesScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ValuesScan")
-     ]),
-    ("ExecWindowAgg",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("WindowAgg")
-     ]),
-    ("ExecWorkTableScan",
-     [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("WorkTableScan")
-     ]),
+    # ("ExecAppend",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Append")
+    #  ]),
+    # ("ExecCteScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("CteScan")
+    #  ]),
+    # ("ExecCustomScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("CustomScan")
+    #  ]),
+    # ("ExecForeignScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ForeignScan")
+    #  ]),
+    # ("ExecFunctionScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("FunctionScan")
+    #  ]),
+    # ("ExecGather",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Gather")
+    #  ]),
+    # ("ExecGatherMerge",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("GatherMerge")
+    #  ]),
+    # ("ExecGroup",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Group")
+    #  ]),
+    # ("ExecHashJoinImpl",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("HashJoin")
+    #  ]),
+    # ("ExecIncrementalSort",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("IncrementalSort")
+    #  ]),
+    # ("ExecIndexOnlyScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("IndexOnlyScan")
+    #  ]),
+    # ("ExecIndexScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("IndexScan")
+    #  ]),
+    # ("ExecLimit",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Limit")
+    #  ]),
+    # ("ExecLockRows",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("LockRows")
+    #  ]),
+    # ("ExecMaterial",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Material")
+    #  ]),
+    # ("ExecMergeAppend",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("MergeAppend")
+    #  ]),
+    # ("ExecMergeJoin",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("MergeJoin")
+    #  ]),
+    # ("ExecModifyTable",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ModifyTable")
+    #  ]),
+    # ("ExecNamedTuplestoreScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("NamedTuplestoreScan")
+    #  ]),
+    # ("ExecNestLoop",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("NestLoop")
+    #  ]),
+    # ("ExecProjectSet",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ProjectSet")
+    #  ]),
+    # ("ExecRecursiveUnion",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("RecursiveUnion")
+    #  ]),
+    # ("ExecResult",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Result")
+    #  ]),
+    # ("ExecSampleScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("SampleScan")
+    #  ]),
+    # ("ExecSeqScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Scan")
+    #  ]),
+    # ("ExecSetOp",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("SetOp")
+    #  ]),
+    # ("ExecSort",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Sort")
+    #  ]),
+    # ("ExecSubPlan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Plan")
+    #  ]),
+    # ("ExecSubqueryScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("SubqueryScan")
+    #  ]),
+    # ("ExecTableFuncScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("TableFuncScan")
+    #  ]),
+    # ("ExecTidScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("TidScan")
+    #  ]),
+    # ("ExecUnique",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("Unique")
+    #  ]),
+    # ("ExecValuesScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("ValuesScan")
+    #  ]),
+    # ("ExecWindowAgg",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("WindowAgg")
+    #  ]),
+    # ("ExecWorkTableScan",
+    #  [
+    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+    #      Feature("WorkTableScan")
+    #  ]),
 ]
 
 # The metrics to be defined for every OU.
@@ -387,8 +395,8 @@ class OperatingUnit:
                 assert (feature.alignment is not None), 'Feature is a struct, so it needs alignment information.'
                 # Add all of the struct's fields, sticking the original struct's alignment value on the first attribute.
                 for i, column in enumerate(feature.bpf_tuple):
-                    alignment_string = '__attribute__((aligned ({})))'.format(feature.alignment) if i == 0 else ''
-                    struct_def = struct_def + ('{} {} {};\n'.format(column.bpf_type, column.name, alignment_string))
+                    alignment_string = ' __attribute__ ((aligned ({})))'.format(feature.alignment) if i == 0 else ''
+                    struct_def = struct_def + ('{} {}{};\n'.format(column.bpf_type, column.name, alignment_string))
             else:
                 # It's a single stack-allocated argument that we can read directly.
                 assert (len(feature.bpf_tuple) == 1), 'How can something not using readarg_p have multiple fields?'

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -118,181 +118,181 @@ OU_DEFS = [
          Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
          Feature("Agg")
      ]),
-    # ("ExecAppend",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Append")
-    #  ]),
-    # ("ExecCteScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("CteScan")
-    #  ]),
-    # ("ExecCustomScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("CustomScan")
-    #  ]),
-    # ("ExecForeignScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ForeignScan")
-    #  ]),
-    # ("ExecFunctionScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("FunctionScan")
-    #  ]),
-    # ("ExecGather",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Gather")
-    #  ]),
-    # ("ExecGatherMerge",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("GatherMerge")
-    #  ]),
-    # ("ExecGroup",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Group")
-    #  ]),
-    # ("ExecHashJoinImpl",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("HashJoin")
-    #  ]),
-    # ("ExecIncrementalSort",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("IncrementalSort")
-    #  ]),
-    # ("ExecIndexOnlyScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("IndexOnlyScan")
-    #  ]),
-    # ("ExecIndexScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("IndexScan")
-    #  ]),
-    # ("ExecLimit",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Limit")
-    #  ]),
-    # ("ExecLockRows",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("LockRows")
-    #  ]),
-    # ("ExecMaterial",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Material")
-    #  ]),
-    # ("ExecMergeAppend",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("MergeAppend")
-    #  ]),
-    # ("ExecMergeJoin",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("MergeJoin")
-    #  ]),
-    # ("ExecModifyTable",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ModifyTable")
-    #  ]),
-    # ("ExecNamedTuplestoreScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("NamedTuplestoreScan")
-    #  ]),
-    # ("ExecNestLoop",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("NestLoop")
-    #  ]),
-    # ("ExecProjectSet",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ProjectSet")
-    #  ]),
-    # ("ExecRecursiveUnion",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("RecursiveUnion")
-    #  ]),
-    # ("ExecResult",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Result")
-    #  ]),
-    # ("ExecSampleScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("SampleScan")
-    #  ]),
-    # ("ExecSeqScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Scan")
-    #  ]),
-    # ("ExecSetOp",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("SetOp")
-    #  ]),
-    # ("ExecSort",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Sort")
-    #  ]),
-    # ("ExecSubPlan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Plan")
-    #  ]),
-    # ("ExecSubqueryScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("SubqueryScan")
-    #  ]),
-    # ("ExecTableFuncScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("TableFuncScan")
-    #  ]),
-    # ("ExecTidScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("TidScan")
-    #  ]),
-    # ("ExecUnique",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("Unique")
-    #  ]),
-    # ("ExecValuesScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("ValuesScan")
-    #  ]),
-    # ("ExecWindowAgg",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("WindowAgg")
-    #  ]),
-    # ("ExecWorkTableScan",
-    #  [
-    #      Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-    #      Feature("WorkTableScan")
-    #  ]),
+    ("ExecAppend",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Append")
+     ]),
+    ("ExecCteScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("CteScan")
+     ]),
+    ("ExecCustomScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("CustomScan")
+     ]),
+    ("ExecForeignScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ForeignScan")
+     ]),
+    ("ExecFunctionScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("FunctionScan")
+     ]),
+    ("ExecGather",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Gather")
+     ]),
+    ("ExecGatherMerge",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("GatherMerge")
+     ]),
+    ("ExecGroup",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Group")
+     ]),
+    ("ExecHashJoinImpl",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("HashJoin")
+     ]),
+    ("ExecIncrementalSort",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("IncrementalSort")
+     ]),
+    ("ExecIndexOnlyScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("IndexOnlyScan")
+     ]),
+    ("ExecIndexScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("IndexScan")
+     ]),
+    ("ExecLimit",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Limit")
+     ]),
+    ("ExecLockRows",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("LockRows")
+     ]),
+    ("ExecMaterial",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Material")
+     ]),
+    ("ExecMergeAppend",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("MergeAppend")
+     ]),
+    ("ExecMergeJoin",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("MergeJoin")
+     ]),
+    ("ExecModifyTable",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ModifyTable")
+     ]),
+    ("ExecNamedTuplestoreScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("NamedTuplestoreScan")
+     ]),
+    ("ExecNestLoop",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("NestLoop")
+     ]),
+    ("ExecProjectSet",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ProjectSet")
+     ]),
+    ("ExecRecursiveUnion",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("RecursiveUnion")
+     ]),
+    ("ExecResult",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Result")
+     ]),
+    ("ExecSampleScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("SampleScan")
+     ]),
+    ("ExecSeqScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Scan")
+     ]),
+    ("ExecSetOp",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("SetOp")
+     ]),
+    ("ExecSort",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Sort")
+     ]),
+    ("ExecSubPlan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Plan")
+     ]),
+    ("ExecSubqueryScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("SubqueryScan")
+     ]),
+    ("ExecTableFuncScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("TableFuncScan")
+     ]),
+    ("ExecTidScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("TidScan")
+     ]),
+    ("ExecUnique",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("Unique")
+     ]),
+    ("ExecValuesScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("ValuesScan")
+     ]),
+    ("ExecWindowAgg",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("WindowAgg")
+     ]),
+    ("ExecWorkTableScan",
+     [
+         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
+         Feature("WorkTableScan")
+     ]),
 ]
 
 # The metrics to be defined for every OU.

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -37,7 +37,7 @@ class BPFType(str, Enum):
 class BPFVariable:
     name: str
     c_type: clang.cindex.TypeKind
-    alignment: int = None
+    alignment: int = None  # Non-None for the first field of a struct, using alignment value of the struct.
 
     def alignment_string(self):
         return ' __attribute__ ((aligned ({})))'.format(self.alignment) if self.alignment is not None else ''
@@ -118,7 +118,7 @@ class Feature:
         True if bpf_usdt_readarg_p should be used.
         False if bpf_usdt_readarg should be used.
     bpf_tuple : Tuple[BPFVariable]
-        A tuple of all the BPF-typed variables that comprise this feature.
+        A tuple of all the BPF-typed variables that comprise this feature. First entry should have an alignment.
     """
     name: str
     readarg_p: bool = None

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -77,15 +77,7 @@ class BPFVariable:
         elif self.c_type == clang.cindex.TypeKind.DOUBLE:
             return str(struct.unpack('d', getattr(output_event, self.name).to_bytes(8, byteorder=sys.byteorder))[0])
         else:
-            print(dir(output_event))
-            string_value = None
-            try:
-                string_value = str(getattr(output_event, self.name))
-            except AttributeError as e:
-                print(self.name)
-                print(output_event)
-                exit()
-            return
+            return str(getattr(output_event, self.name))
 
 
 @dataclass

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -168,6 +168,8 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     num_cpus = len(utils.get_online_cpus())
     collector_c = collector_c.replace("MAX_CPUS", str(num_cpus))
 
+    print(collector_c, file=open('./test.c', 'w'))
+
     # Attach USDT probes to the target PID.
     collector_probes = USDT(pid=pid)
     for ou in operating_units:

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -156,8 +156,8 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     collector_c = '\n'.join(helper_struct_defs.values()) + '\n' + collector_c
 
     # Replace remaining placeholders in C code.
-    defs = ['{} {}{}'.format(model.CLANG_TO_BPF[metric.c_type], metric.name, metric.alignment_string()) for i, metric
-            in enumerate(metrics)]
+    defs = ['{} {}{}'.format(model.CLANG_TO_BPF[metric.c_type], metric.name, metric.alignment_string()) for metric in
+            metrics]
     metrics_struct = ';\n'.join(defs) + ';'
     collector_c = collector_c.replace("SUBST_METRICS", metrics_struct)
     accumulate = ['lhs->{} += rhs->{}'.format(metric.name, metric.name) for metric in metrics if

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -156,7 +156,9 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     collector_c = '\n'.join(helper_struct_defs.values()) + '\n' + collector_c
 
     # Replace remaining placeholders in C code.
-    defs = ['{} {}'.format(metric.bpf_type, metric.name) for metric in metrics]
+    defs = ['{} {}{}'.format(model.CLANG_TO_BPF[metric.c_type], metric.name,
+                             ' __attribute__ ((aligned ({})))'.format(metric.alignment) if i == 0 else '') for i, metric
+            in enumerate(metrics)]
     metrics_struct = ';\n'.join(defs) + ';'
     collector_c = collector_c.replace("SUBST_METRICS", metrics_struct)
     accumulate = ['lhs->{} += rhs->{}'.format(metric.name, metric.name) for metric in metrics if
@@ -168,7 +170,7 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     num_cpus = len(utils.get_online_cpus())
     collector_c = collector_c.replace("MAX_CPUS", str(num_cpus))
 
-    # print(collector_c, file=open('./test.c', 'w'))
+    print(collector_c, file=open('./test.c', 'w'))
 
     # Attach USDT probes to the target PID.
     collector_probes = USDT(pid=pid)

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -168,8 +168,6 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     num_cpus = len(utils.get_online_cpus())
     collector_c = collector_c.replace("MAX_CPUS", str(num_cpus))
 
-    print(collector_c, file=open('./test.c', 'w'))
-
     # Attach USDT probes to the target PID.
     collector_probes = USDT(pid=pid)
     for ou in operating_units:

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -169,8 +169,6 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     num_cpus = len(utils.get_online_cpus())
     collector_c = collector_c.replace("MAX_CPUS", str(num_cpus))
 
-    # print(collector_c, file=open('./test.c', 'w'))
-
     # Attach USDT probes to the target PID.
     collector_probes = USDT(pid=pid)
     for ou in operating_units:
@@ -263,7 +261,6 @@ def lost_something(num_lost):
     pass
 
 
-
 def processor(ou, buffered_strings, outdir):
     setproctitle.setproctitle("TScout Processor {}".format(ou.name()))
 
@@ -348,7 +345,7 @@ if __name__ == "__main__":
             ou_processor_queue = mp.Queue()
             ou_processor_queues.append(ou_processor_queue)
             ou_processor = mp.Process(target=processor,
-                                    args=(ou, ou_processor_queue, outdir),)
+                                      args=(ou, ou_processor_queue, outdir), )
             ou_processor.start()
             ou_processors.append(ou_processor)
 

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -156,8 +156,7 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     collector_c = '\n'.join(helper_struct_defs.values()) + '\n' + collector_c
 
     # Replace remaining placeholders in C code.
-    defs = ['{} {}{}'.format(model.CLANG_TO_BPF[metric.c_type], metric.name,
-                             ' __attribute__ ((aligned ({})))'.format(metric.alignment) if i == 0 else '') for i, metric
+    defs = ['{} {}{}'.format(model.CLANG_TO_BPF[metric.c_type], metric.name, metric.alignment_string()) for i, metric
             in enumerate(metrics)]
     metrics_struct = ';\n'.join(defs) + ';'
     collector_c = collector_c.replace("SUBST_METRICS", metrics_struct)
@@ -170,7 +169,7 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     num_cpus = len(utils.get_online_cpus())
     collector_c = collector_c.replace("MAX_CPUS", str(num_cpus))
 
-    print(collector_c, file=open('./test.c', 'w'))
+    # print(collector_c, file=open('./test.c', 'w'))
 
     # Attach USDT probes to the target PID.
     collector_probes = USDT(pid=pid)

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -168,6 +168,8 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     num_cpus = len(utils.get_online_cpus())
     collector_c = collector_c.replace("MAX_CPUS", str(num_cpus))
 
+    # print(collector_c, file=open('./test.c', 'w'))
+
     # Attach USDT probes to the target PID.
     collector_probes = USDT(pid=pid)
     for ou in operating_units:


### PR DESCRIPTION
This is more boilerplate for future work when we try to stash multiple structs into an OU's features. My hypothesis is that because a struct and its first field use have the same memory address (per C standard) that this gives us the best chance of keeping memory layouts of adjacent unrolled structs that might otherwise end up with different layouts (due to padding) at the boundary fields. I've started seeing garbage values from `memcpy`ing structs under this scenario and this PR attempts to fix the issue.

### Changes
- `Field` class in `ClangParser` has an optional alignment attribute to carry necessary metadata over to TScout's code generation.
- `ClangParser`'s `_construct_fully_expanded_fields` tags the first `Field` of a struct/class/union with that object's alignment.
- `BPFVariable` no longer has a `BPFType` field. We already have a map between C types and their corresponding BPF types. Keeping fields for this is a huge footgun when we can enforce consistency by just using the map.
- Moved aforementioned `CLANG_TO_BPF` type map to global scope to make it more accessible.
- `features_struct` function changed from list comprehension to handle a bit complex logic between `readarg_p` `Feature`s.
- `BPFVariable` gets an `alignment_string` method to generate the correct syntax for the field.
- Moved `cpu_id` to last field of metrics/Ys to try to order those fields by size.