### PR TITLE
Capture the worker PID in cpu_end collector

### DIFF
--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -350,6 +350,8 @@ OU_METRICS = (
                 c_type=clang.cindex.TypeKind.ULONG),
     BPFVariable(name="elapsed_us",
                 c_type=clang.cindex.TypeKind.ULONG),
+    BPFVariable(name="pid",
+                c_type=clang.cindex.TypeKind.UINT),
     BPFVariable(name="cpu_id",
                 c_type=clang.cindex.TypeKind.UCHAR),
 )

--- a/cmudb/tscout/probes.c
+++ b/cmudb/tscout/probes.c
@@ -111,6 +111,7 @@ static bool cpu_end(struct resource_metrics *const metrics) {
   metrics->ref_cpu_cycles = end_value - metrics->ref_cpu_cycles;
 
   metrics->cpu_id = cpu_k;
+  metrics->pid = bpf_get_current_pid_tgid();
 
   return true;
 }


### PR DESCRIPTION
 This disambiguates training data in the multi-terminal workload scenario.