### PR TITLE
Pass child plan node IDs as USDT args and save as metadata

### DIFF
--- a/cmudb/tscout/collector.c
+++ b/cmudb/tscout/collector.c
@@ -22,7 +22,6 @@ BPF_HASH(complete_metrics, u64, struct resource_metrics, 32);  // TODO(Matt): Th
 // Stores a snapshot of the metrics at START Marker, waiting to hit an END Marker
 BPF_HASH(running_metrics, u64, struct resource_metrics, 32);  // TODO(Matt): Think about this size more
 
-// We expect `plan_node_id` to be unique within the call stack, even if OUs are recursive.
 static u64 ou_key(const u32 ou, const s32 ou_instance) { return ((u64)ou) << 32 | ou_instance; }
 
 static void metrics_accumulate(struct resource_metrics *const lhs, const struct resource_metrics *const rhs) {

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -162,6 +162,8 @@ void SUBST_OU_flush(struct pt_regs *ctx) {
   // Copy completed metrics to output struct
   __builtin_memcpy(&(output->SUBST_FIRST_METRIC), flush_metrics, sizeof(struct resource_metrics));
 
+  output->pid = bpf_get_current_pid_tgid();
+
   // Send output struct to userspace via subsystem's perf ring buffer.
   collector_results_SUBST_INDEX.perf_submit(ctx, output, sizeof(struct SUBST_OU_output));
   SUBST_OU_reset(ou_instance);

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -125,7 +125,11 @@ class Feature:
     bpf_tuple: Tuple[BPFVariable] = None
 
 
-QUERY_ID = (BPFVariable("query_id", clang.cindex.TypeKind.ULONG),)
+QUERY_ID = Feature("QueryId", readarg_p=False, bpf_tuple=(BPFVariable("query_id", clang.cindex.TypeKind.ULONG),))
+LEFT_CHILD_NODE_ID = Feature("left_child_plan_node_id", readarg_p=False,
+                             bpf_tuple=(BPFVariable("left_child_plan_node_id", clang.cindex.TypeKind.INT),))
+RIGHT_CHILD_NODE_ID = Feature("right_child_plan_node_id", readarg_p=False,
+                              bpf_tuple=(BPFVariable("right_child_plan_node_id", clang.cindex.TypeKind.INT),))
 
 """
 An OU is specified via (operator, postgres_function, feature_types).
@@ -141,183 +145,255 @@ feature_types : List[Feature]
 OU_DEFS = [
     ("ExecAgg",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Agg")
+         QUERY_ID,
+         Feature("Agg"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecAppend",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Append")
+         QUERY_ID,
+         Feature("Append"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecCteScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("CteScan")
+         QUERY_ID,
+         Feature("CteScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecCustomScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("CustomScan")
+         QUERY_ID,
+         Feature("CustomScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecForeignScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ForeignScan")
+         QUERY_ID,
+         Feature("ForeignScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecFunctionScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("FunctionScan")
+         QUERY_ID,
+         Feature("FunctionScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecGather",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Gather")
+         QUERY_ID,
+         Feature("Gather"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecGatherMerge",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("GatherMerge")
+         QUERY_ID,
+         Feature("GatherMerge"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecGroup",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Group")
+         QUERY_ID,
+         Feature("Group"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecHashJoinImpl",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("HashJoin")
+         QUERY_ID,
+         Feature("HashJoin"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecIncrementalSort",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IncrementalSort")
+         QUERY_ID,
+         Feature("IncrementalSort"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecIndexOnlyScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IndexOnlyScan")
+         QUERY_ID,
+         Feature("IndexOnlyScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecIndexScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("IndexScan")
+         QUERY_ID,
+         Feature("IndexScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecLimit",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Limit")
+         QUERY_ID,
+         Feature("Limit"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecLockRows",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("LockRows")
+         QUERY_ID,
+         Feature("LockRows"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecMaterial",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Material")
+         QUERY_ID,
+         Feature("Material"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecMergeAppend",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MergeAppend")
+         QUERY_ID,
+         Feature("MergeAppend"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecMergeJoin",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("MergeJoin")
+         QUERY_ID,
+         Feature("MergeJoin"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecModifyTable",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ModifyTable")
+         QUERY_ID,
+         Feature("ModifyTable"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecNamedTuplestoreScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("NamedTuplestoreScan")
+         QUERY_ID,
+         Feature("NamedTuplestoreScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecNestLoop",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("NestLoop")
+         QUERY_ID,
+         Feature("NestLoop"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecProjectSet",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ProjectSet")
+         QUERY_ID,
+         Feature("ProjectSet"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecRecursiveUnion",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("RecursiveUnion")
+         QUERY_ID,
+         Feature("RecursiveUnion"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecResult",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Result")
+         QUERY_ID,
+         Feature("Result"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecSampleScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SampleScan")
+         QUERY_ID,
+         Feature("SampleScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecSeqScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Scan")
+         QUERY_ID,
+         Feature("Scan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecSetOp",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SetOp")
+         QUERY_ID,
+         Feature("SetOp"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecSort",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Sort")
+         QUERY_ID,
+         Feature("Sort"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecSubPlan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Plan")
+         QUERY_ID,
+         Feature("Plan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecSubqueryScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("SubqueryScan")
+         QUERY_ID,
+         Feature("SubqueryScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecTableFuncScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("TableFuncScan")
+         QUERY_ID,
+         Feature("TableFuncScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecTidScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("TidScan")
+         QUERY_ID,
+         Feature("TidScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecUnique",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("Unique")
+         QUERY_ID,
+         Feature("Unique"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecValuesScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("ValuesScan")
+         QUERY_ID,
+         Feature("ValuesScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecWindowAgg",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("WindowAgg")
+         QUERY_ID,
+         Feature("WindowAgg"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
     ("ExecWorkTableScan",
      [
-         Feature("QueryId", readarg_p=False, bpf_tuple=QUERY_ID),
-         Feature("WorkTableScan")
+         QUERY_ID,
+         Feature("WorkTableScan"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID
      ]),
 ]
 

--- a/cmudb/tscout/probes.c
+++ b/cmudb/tscout/probes.c
@@ -111,7 +111,6 @@ static bool cpu_end(struct resource_metrics *const metrics) {
   metrics->ref_cpu_cycles = end_value - metrics->ref_cpu_cycles;
 
   metrics->cpu_id = cpu_k;
-  metrics->pid = bpf_get_current_pid_tgid();
 
   return true;
 }

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -3277,7 +3277,9 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
 							   node->aggstrategy == AGG_MIXED);
 
     TS_MARKER(ExecAgg_features, node->plan.plan_node_id,
-                estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -120,7 +120,9 @@ ExecInitAppend(Append *node, EState *estate, int eflags)
 				j;
 
         TS_MARKER(ExecAppend_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -180,7 +180,9 @@ ExecInitCteScan(CteScan *node, EState *estate, int eflags)
 	ParamExecData *prmdata;
 
         TS_MARKER(ExecCteScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -35,7 +35,9 @@ ExecInitCustomScan(CustomScan *cscan, EState *estate, int eflags)
 	Index		tlistvarno;
 
         TS_MARKER(ExecCustomScan_features, cscan->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, cscan);
+                  estate->es_plannedstmt->queryId, cscan,
+                  ChildPlanNodeId(cscan->scan.plan.lefttree),
+                  ChildPlanNodeId(cscan->scan.plan.righttree));
 
 	/*
 	 * Allocate the CustomScanState object.  We let the custom scan provider

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -144,7 +144,9 @@ ExecInitForeignScan(ForeignScan *node, EState *estate, int eflags)
 	FdwRoutine *fdwroutine;
 
         TS_MARKER(ExecForeignScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -290,7 +290,9 @@ ExecInitFunctionScan(FunctionScan *node, EState *estate, int eflags)
 	ListCell   *lc;
 
         TS_MARKER(ExecFunctionScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeGather.c
+++ b/src/backend/executor/nodeGather.c
@@ -63,7 +63,9 @@ ExecInitGather(Gather *node, EState *estate, int eflags)
 	TupleDesc	tupDesc;
 
         TS_MARKER(ExecGather_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* Gather node doesn't have innerPlan node. */
 	Assert(innerPlan(node) == NULL);

--- a/src/backend/executor/nodeGatherMerge.c
+++ b/src/backend/executor/nodeGatherMerge.c
@@ -77,7 +77,9 @@ ExecInitGatherMerge(GatherMerge *node, EState *estate, int eflags)
 	TupleDesc	tupDesc;
 
         TS_MARKER(ExecGatherMerge_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* Gather merge node doesn't have innerPlan node. */
 	Assert(innerPlan(node) == NULL);

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -168,7 +168,9 @@ ExecInitGroup(Group *node, EState *estate, int eflags)
 	const TupleTableSlotOps *tts_ops;
 
         TS_MARKER(ExecGroup_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -115,6 +115,7 @@
 #include "miscadmin.h"
 #include "pgstat.h"
 #include "tscout/marker.h"
+#include "tscout/executors.h"
 #include "utils/memutils.h"
 #include "utils/sharedtuplestore.h"
 
@@ -637,7 +638,9 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
 	const TupleTableSlotOps *ops;
 
         TS_MARKER(ExecHashJoinImpl_features, node->join.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->join.plan.lefttree),
+                  ChildPlanNodeId(node->join.plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeIncrementalSort.c
+++ b/src/backend/executor/nodeIncrementalSort.c
@@ -980,7 +980,9 @@ ExecInitIncrementalSort(IncrementalSort *node, EState *estate, int eflags)
 	IncrementalSortState *incrsortstate;
 
         TS_MARKER(ExecIncrementalSort_features, node->sort.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->sort.plan.lefttree),
+                  ChildPlanNodeId(node->sort.plan.righttree));
 
 	SO_printf("ExecInitIncrementalSort: initializing sort node\n");
 

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -503,7 +503,9 @@ ExecInitIndexOnlyScan(IndexOnlyScan *node, EState *estate, int eflags)
 	TupleDesc	tupDesc;
 
         TS_MARKER(ExecIndexOnlyScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	/*
 	 * create state structure

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -909,7 +909,9 @@ ExecInitIndexScan(IndexScan *node, EState *estate, int eflags)
 	LOCKMODE	lockmode;
 
         TS_MARKER(ExecIndexScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	/*
 	 * create state structure

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -454,7 +454,9 @@ ExecInitLimit(Limit *node, EState *estate, int eflags)
 	Plan	   *outerPlan;
 
         TS_MARKER(ExecLimit_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -300,7 +300,9 @@ ExecInitLockRows(LockRows *node, EState *estate, int eflags)
 	ListCell   *lc;
 
         TS_MARKER(ExecLockRows_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -170,7 +170,9 @@ ExecInitMaterial(Material *node, EState *estate, int eflags)
 	Plan	   *outerPlan;
 
         TS_MARKER(ExecMaterial_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/*
 	 * create state structure

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -73,7 +73,9 @@ ExecInitMergeAppend(MergeAppend *node, EState *estate, int eflags)
 				j;
 
         TS_MARKER(ExecMergeAppend_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1444,7 +1444,9 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
 	const TupleTableSlotOps *innerOps;
 
         TS_MARKER(ExecMergeJoin_features, node->join.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->join.plan.lefttree),
+                  ChildPlanNodeId(node->join.plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2721,7 +2721,9 @@ ExecInitModifyTable(ModifyTable *node, EState *estate, int eflags)
 	Relation	rel;
 
         TS_MARKER(ExecModifyTable_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -87,8 +87,10 @@ ExecInitNamedTuplestoreScan(NamedTuplestoreScan *node, EState *estate, int eflag
 	NamedTuplestoreScanState *scanstate;
 	EphemeralNamedRelation enr;
 
-        TS_MARKER(ExecNamedTuplestoreScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+        TS_MARKER(ExecNamedTuplestoreScan_features,
+                  node->scan.plan.plan_node_id, estate->es_plannedstmt->queryId,
+                  node, ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -268,7 +268,9 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
 	NestLoopState *nlstate;
 
         TS_MARKER(ExecNestLoop_features, node->join.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->join.plan.lefttree),
+                  ChildPlanNodeId(node->join.plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeProjectSet.c
+++ b/src/backend/executor/nodeProjectSet.c
@@ -227,7 +227,9 @@ ExecInitProjectSet(ProjectSet *node, EState *estate, int eflags)
 	int			off;
 
         TS_MARKER(ExecProjectSet_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_MARK | EXEC_FLAG_BACKWARD)));

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -173,7 +173,9 @@ ExecInitRecursiveUnion(RecursiveUnion *node, EState *estate, int eflags)
 	ParamExecData *prmdata;
 
         TS_MARKER(ExecRecursiveUnion_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -186,7 +186,9 @@ ExecInitResult(Result *node, EState *estate, int eflags)
 	ResultState *resstate;
 
         TS_MARKER(ExecResult_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_MARK | EXEC_FLAG_BACKWARD)) ||

--- a/src/backend/executor/nodeSamplescan.c
+++ b/src/backend/executor/nodeSamplescan.c
@@ -103,7 +103,9 @@ ExecInitSampleScan(SampleScan *node, EState *estate, int eflags)
 	TsmRoutine *tsm;
 
         TS_MARKER(ExecSampleScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	Assert(outerPlan(node) == NULL);
 	Assert(innerPlan(node) == NULL);

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -127,7 +127,9 @@ ExecInitSeqScan(SeqScan *node, EState *estate, int eflags)
 	SeqScanState *scanstate;
 
         TS_MARKER(ExecSeqScan_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/*
 	 * Once upon a time it was possible to have an outerPlan of a SeqScan, but

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -487,7 +487,9 @@ ExecInitSetOp(SetOp *node, EState *estate, int eflags)
 	TupleDesc	outerDesc;
 
         TS_MARKER(ExecSetOp_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -172,7 +172,9 @@ ExecInitSort(Sort *node, EState *estate, int eflags)
 	SortState  *sortstate;
 
         TS_MARKER(ExecSort_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	SO1_printf("ExecInitSort: %s\n",
 			   "initializing sort node");

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -106,7 +106,9 @@ Datum pg_attribute_always_inline ExecSubPlan(SubPlanState *node,
   Datum result;
   TS_MARKER(ExecSubPlan_features, node->planstate->plan->plan_node_id,
             node->planstate->state->es_plannedstmt->queryId,
-            node->planstate->plan);
+            node->planstate->plan,
+            ChildPlanNodeId(node->planstate->plan->lefttree),
+            ChildPlanNodeId(node->planstate->plan->righttree));
   TS_MARKER(ExecSubPlan_begin, node->planstate->plan->plan_node_id);
 
   result = WrappedExecSubPlan(node, econtext, isNull);

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -102,7 +102,9 @@ ExecInitSubqueryScan(SubqueryScan *node, EState *estate, int eflags)
 	SubqueryScanState *subquerystate;
 
         TS_MARKER(ExecSubqueryScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeTableFuncscan.c
+++ b/src/backend/executor/nodeTableFuncscan.c
@@ -118,7 +118,9 @@ ExecInitTableFuncScan(TableFuncScan *node, EState *estate, int eflags)
 	int			i;
 
         TS_MARKER(ExecTableFuncScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -506,7 +506,9 @@ ExecInitTidScan(TidScan *node, EState *estate, int eflags)
 	Relation	currentRelation;
         
         TS_MARKER(ExecTidScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	/*
 	 * create state structure

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -120,7 +120,9 @@ ExecInitUnique(Unique *node, EState *estate, int eflags)
 	UniqueState *uniquestate;
 
         TS_MARKER(ExecUnique_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -220,7 +220,9 @@ ExecInitValuesScan(ValuesScan *node, EState *estate, int eflags)
 	PlanState  *planstate;
 
         TS_MARKER(ExecValuesScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	/*
 	 * ValuesScan should not have any children.

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -2266,7 +2266,9 @@ ExecInitWindowAgg(WindowAgg *node, EState *estate, int eflags)
 	ListCell   *l;
 
         TS_MARKER(ExecWindowAgg_features, node->plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->plan.lefttree),
+                  ChildPlanNodeId(node->plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -134,7 +134,9 @@ ExecInitWorkTableScan(WorkTableScan *node, EState *estate, int eflags)
 	WorkTableScanState *scanstate;
 
         TS_MARKER(ExecWorkTableScan_features, node->scan.plan.plan_node_id,
-                  estate->es_plannedstmt->queryId, node);
+                  estate->es_plannedstmt->queryId, node,
+                  ChildPlanNodeId(node->scan.plan.lefttree),
+                  ChildPlanNodeId(node->scan.plan.righttree));
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -2,6 +2,11 @@
 
 #include "tscout/marker.h"
 
+// TODO(Matt): Consider a BPF-level Encoder for this as a proof of concept.
+static int ChildPlanNodeId(const struct Plan *const child_plan_node) {
+  return child_plan_node ? child_plan_node->plan_node_id : -1;
+}
+
 /*
  * Wrapper to add TScout markers to an executor. In the executor file, rename
  * the current Exec<blah> function to WrappedExec<blah> and then add


### PR DESCRIPTION
This information is useful for reconstructing the plan tree without doing the parantheses-matching that relies on start and stop times (i.e., actually executing the query). For example, on a simple
```sql
select count(*) from foo;
```
this yields a plan tree with an Agg node at the root with a single SeqScan child. The resulting CSVs look like:
**ExecAgg.csv**
```
...,Agg_plan_plan_node_id,...,left_child_plan_node_id,right_child_plan_node_id,...
...,0,...,1,-1,...
```
**ExecSeqScan.csv**
```
...,Scan_plan_plan_node_id,...,left_child_plan_node_id,right_child_plan_node_id,...
...,1,...,-1,-1,...
```
I implemented this using USDT args and doing the pointer chasing in user-space, however this may be a candidate for BPF-level encoding in the future.