### PR TITLE
Pass statement timestamp as USDT arg and save as metadata

### DIFF
--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -130,6 +130,8 @@ LEFT_CHILD_NODE_ID = Feature("left_child_plan_node_id", readarg_p=False,
                              bpf_tuple=(BPFVariable("left_child_plan_node_id", clang.cindex.TypeKind.INT),))
 RIGHT_CHILD_NODE_ID = Feature("right_child_plan_node_id", readarg_p=False,
                               bpf_tuple=(BPFVariable("right_child_plan_node_id", clang.cindex.TypeKind.INT),))
+STATEMENT_TIMESTAMP = Feature("statement_timestamp", readarg_p=False,
+                              bpf_tuple=(BPFVariable("statement_timestamp", clang.cindex.TypeKind.LONG),))
 
 """
 An OU is specified via (operator, postgres_function, feature_types).
@@ -148,252 +150,288 @@ OU_DEFS = [
          QUERY_ID,
          Feature("Agg"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecAppend",
      [
          QUERY_ID,
          Feature("Append"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecCteScan",
      [
          QUERY_ID,
          Feature("CteScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecCustomScan",
      [
          QUERY_ID,
          Feature("CustomScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecForeignScan",
      [
          QUERY_ID,
          Feature("ForeignScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecFunctionScan",
      [
          QUERY_ID,
          Feature("FunctionScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecGather",
      [
          QUERY_ID,
          Feature("Gather"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecGatherMerge",
      [
          QUERY_ID,
          Feature("GatherMerge"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecGroup",
      [
          QUERY_ID,
          Feature("Group"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecHashJoinImpl",
      [
          QUERY_ID,
          Feature("HashJoin"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecIncrementalSort",
      [
          QUERY_ID,
          Feature("IncrementalSort"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecIndexOnlyScan",
      [
          QUERY_ID,
          Feature("IndexOnlyScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecIndexScan",
      [
          QUERY_ID,
          Feature("IndexScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecLimit",
      [
          QUERY_ID,
          Feature("Limit"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecLockRows",
      [
          QUERY_ID,
          Feature("LockRows"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecMaterial",
      [
          QUERY_ID,
          Feature("Material"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecMergeAppend",
      [
          QUERY_ID,
          Feature("MergeAppend"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecMergeJoin",
      [
          QUERY_ID,
          Feature("MergeJoin"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecModifyTable",
      [
          QUERY_ID,
          Feature("ModifyTable"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecNamedTuplestoreScan",
      [
          QUERY_ID,
          Feature("NamedTuplestoreScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecNestLoop",
      [
          QUERY_ID,
          Feature("NestLoop"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecProjectSet",
      [
          QUERY_ID,
          Feature("ProjectSet"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecRecursiveUnion",
      [
          QUERY_ID,
          Feature("RecursiveUnion"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecResult",
      [
          QUERY_ID,
          Feature("Result"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecSampleScan",
      [
          QUERY_ID,
          Feature("SampleScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecSeqScan",
      [
          QUERY_ID,
          Feature("Scan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecSetOp",
      [
          QUERY_ID,
          Feature("SetOp"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecSort",
      [
          QUERY_ID,
          Feature("Sort"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecSubPlan",
      [
          QUERY_ID,
          Feature("Plan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecSubqueryScan",
      [
          QUERY_ID,
          Feature("SubqueryScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecTableFuncScan",
      [
          QUERY_ID,
          Feature("TableFuncScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecTidScan",
      [
          QUERY_ID,
          Feature("TidScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecUnique",
      [
          QUERY_ID,
          Feature("Unique"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecValuesScan",
      [
          QUERY_ID,
          Feature("ValuesScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecWindowAgg",
      [
          QUERY_ID,
          Feature("WindowAgg"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
     ("ExecWorkTableScan",
      [
          QUERY_ID,
          Feature("WorkTableScan"),
          LEFT_CHILD_NODE_ID,
-         RIGHT_CHILD_NODE_ID
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
      ]),
 ]
 

--- a/src/backend/executor/nodeAgg.c
+++ b/src/backend/executor/nodeAgg.c
@@ -241,6 +241,7 @@
 
 #include "access/htup_details.h"
 #include "access/parallel.h"
+#include "access/xact.h"
 #include "catalog/objectaccess.h"
 #include "catalog/pg_aggregate.h"
 #include "catalog/pg_proc.h"
@@ -3279,7 +3280,8 @@ ExecInitAgg(Agg *node, EState *estate, int eflags)
     TS_MARKER(ExecAgg_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeAppend.c
+++ b/src/backend/executor/nodeAppend.c
@@ -57,6 +57,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/execAsync.h"
 #include "executor/execdebug.h"
 #include "executor/execPartition.h"
@@ -122,7 +123,8 @@ ExecInitAppend(Append *node, EState *estate, int eflags)
         TS_MARKER(ExecAppend_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeCtescan.c
+++ b/src/backend/executor/nodeCtescan.c
@@ -15,6 +15,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/execdebug.h"
 #include "executor/nodeCtescan.h"
 #include "miscadmin.h"
@@ -182,7 +183,8 @@ ExecInitCteScan(CteScan *node, EState *estate, int eflags)
         TS_MARKER(ExecCteScan_features, node->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeCustom.c
+++ b/src/backend/executor/nodeCustom.c
@@ -11,6 +11,7 @@
 #include "postgres.h"
 
 #include "access/parallel.h"
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeCustom.h"
 #include "miscadmin.h"
@@ -37,7 +38,8 @@ ExecInitCustomScan(CustomScan *cscan, EState *estate, int eflags)
         TS_MARKER(ExecCustomScan_features, cscan->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, cscan,
                   ChildPlanNodeId(cscan->scan.plan.lefttree),
-                  ChildPlanNodeId(cscan->scan.plan.righttree));
+                  ChildPlanNodeId(cscan->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/*
 	 * Allocate the CustomScanState object.  We let the custom scan provider

--- a/src/backend/executor/nodeForeignscan.c
+++ b/src/backend/executor/nodeForeignscan.c
@@ -22,6 +22,7 @@
  */
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeForeignscan.h"
 #include "foreign/fdwapi.h"
@@ -146,7 +147,8 @@ ExecInitForeignScan(ForeignScan *node, EState *estate, int eflags)
         TS_MARKER(ExecForeignScan_features, node->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeFunctionscan.c
+++ b/src/backend/executor/nodeFunctionscan.c
@@ -22,6 +22,7 @@
  */
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "catalog/pg_type.h"
 #include "executor/nodeFunctionscan.h"
 #include "funcapi.h"
@@ -292,7 +293,8 @@ ExecInitFunctionScan(FunctionScan *node, EState *estate, int eflags)
         TS_MARKER(ExecFunctionScan_features, node->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeGather.c
+++ b/src/backend/executor/nodeGather.c
@@ -65,7 +65,8 @@ ExecInitGather(Gather *node, EState *estate, int eflags)
         TS_MARKER(ExecGather_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* Gather node doesn't have innerPlan node. */
 	Assert(innerPlan(node) == NULL);

--- a/src/backend/executor/nodeGatherMerge.c
+++ b/src/backend/executor/nodeGatherMerge.c
@@ -79,7 +79,8 @@ ExecInitGatherMerge(GatherMerge *node, EState *estate, int eflags)
         TS_MARKER(ExecGatherMerge_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* Gather merge node doesn't have innerPlan node. */
 	Assert(innerPlan(node) == NULL);

--- a/src/backend/executor/nodeGroup.c
+++ b/src/backend/executor/nodeGroup.c
@@ -22,6 +22,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeGroup.h"
 #include "miscadmin.h"
@@ -170,7 +171,8 @@ ExecInitGroup(Group *node, EState *estate, int eflags)
         TS_MARKER(ExecGroup_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -108,6 +108,7 @@
 
 #include "access/htup_details.h"
 #include "access/parallel.h"
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/hashjoin.h"
 #include "executor/nodeHash.h"
@@ -640,7 +641,8 @@ ExecInitHashJoin(HashJoin *node, EState *estate, int eflags)
         TS_MARKER(ExecHashJoinImpl_features, node->join.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->join.plan.lefttree),
-                  ChildPlanNodeId(node->join.plan.righttree));
+                  ChildPlanNodeId(node->join.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeIncrementalSort.c
+++ b/src/backend/executor/nodeIncrementalSort.c
@@ -79,6 +79,7 @@
 #include "postgres.h"
 
 #include "access/htup_details.h"
+#include "access/xact.h"
 #include "executor/execdebug.h"
 #include "executor/nodeIncrementalSort.h"
 #include "miscadmin.h"
@@ -982,7 +983,8 @@ ExecInitIncrementalSort(IncrementalSort *node, EState *estate, int eflags)
         TS_MARKER(ExecIncrementalSort_features, node->sort.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->sort.plan.lefttree),
-                  ChildPlanNodeId(node->sort.plan.righttree));
+                  ChildPlanNodeId(node->sort.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	SO_printf("ExecInitIncrementalSort: initializing sort node\n");
 

--- a/src/backend/executor/nodeIndexonlyscan.c
+++ b/src/backend/executor/nodeIndexonlyscan.c
@@ -505,7 +505,8 @@ ExecInitIndexOnlyScan(IndexOnlyScan *node, EState *estate, int eflags)
         TS_MARKER(ExecIndexOnlyScan_features, node->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/*
 	 * create state structure

--- a/src/backend/executor/nodeIndexscan.c
+++ b/src/backend/executor/nodeIndexscan.c
@@ -911,7 +911,8 @@ ExecInitIndexScan(IndexScan *node, EState *estate, int eflags)
         TS_MARKER(ExecIndexScan_features, node->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/*
 	 * create state structure

--- a/src/backend/executor/nodeLimit.c
+++ b/src/backend/executor/nodeLimit.c
@@ -21,6 +21,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeLimit.h"
 #include "miscadmin.h"
@@ -456,7 +457,8 @@ ExecInitLimit(Limit *node, EState *estate, int eflags)
         TS_MARKER(ExecLimit_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeLockRows.c
+++ b/src/backend/executor/nodeLockRows.c
@@ -302,7 +302,8 @@ ExecInitLockRows(LockRows *node, EState *estate, int eflags)
         TS_MARKER(ExecLockRows_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeMaterial.c
+++ b/src/backend/executor/nodeMaterial.c
@@ -21,6 +21,7 @@
  */
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeMaterial.h"
 #include "miscadmin.h"
@@ -172,7 +173,8 @@ ExecInitMaterial(Material *node, EState *estate, int eflags)
         TS_MARKER(ExecMaterial_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/*
 	 * create state structure

--- a/src/backend/executor/nodeMergeAppend.c
+++ b/src/backend/executor/nodeMergeAppend.c
@@ -38,6 +38,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/execdebug.h"
 #include "executor/execPartition.h"
 #include "executor/nodeMergeAppend.h"
@@ -75,7 +76,8 @@ ExecInitMergeAppend(MergeAppend *node, EState *estate, int eflags)
         TS_MARKER(ExecMergeAppend_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeMergejoin.c
+++ b/src/backend/executor/nodeMergejoin.c
@@ -1446,7 +1446,8 @@ ExecInitMergeJoin(MergeJoin *node, EState *estate, int eflags)
         TS_MARKER(ExecMergeJoin_features, node->join.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->join.plan.lefttree),
-                  ChildPlanNodeId(node->join.plan.righttree));
+                  ChildPlanNodeId(node->join.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeModifyTable.c
+++ b/src/backend/executor/nodeModifyTable.c
@@ -2723,7 +2723,8 @@ ExecInitModifyTable(ModifyTable *node, EState *estate, int eflags)
         TS_MARKER(ExecModifyTable_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeNamedtuplestorescan.c
+++ b/src/backend/executor/nodeNamedtuplestorescan.c
@@ -15,6 +15,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/execdebug.h"
 #include "executor/nodeNamedtuplestorescan.h"
 #include "miscadmin.h"
@@ -90,7 +91,8 @@ ExecInitNamedTuplestoreScan(NamedTuplestoreScan *node, EState *estate, int eflag
         TS_MARKER(ExecNamedTuplestoreScan_features,
                   node->scan.plan.plan_node_id, estate->es_plannedstmt->queryId,
                   node, ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeNestloop.c
+++ b/src/backend/executor/nodeNestloop.c
@@ -21,6 +21,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/execdebug.h"
 #include "executor/nodeNestloop.h"
 #include "miscadmin.h"
@@ -270,7 +271,8 @@ ExecInitNestLoop(NestLoop *node, EState *estate, int eflags)
         TS_MARKER(ExecNestLoop_features, node->join.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->join.plan.lefttree),
-                  ChildPlanNodeId(node->join.plan.righttree));
+                  ChildPlanNodeId(node->join.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeProjectSet.c
+++ b/src/backend/executor/nodeProjectSet.c
@@ -22,6 +22,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeProjectSet.h"
 #include "miscadmin.h"
@@ -229,7 +230,8 @@ ExecInitProjectSet(ProjectSet *node, EState *estate, int eflags)
         TS_MARKER(ExecProjectSet_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_MARK | EXEC_FLAG_BACKWARD)));

--- a/src/backend/executor/nodeRecursiveunion.c
+++ b/src/backend/executor/nodeRecursiveunion.c
@@ -18,6 +18,7 @@
  */
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/execdebug.h"
 #include "executor/nodeRecursiveunion.h"
 #include "miscadmin.h"
@@ -175,7 +176,8 @@ ExecInitRecursiveUnion(RecursiveUnion *node, EState *estate, int eflags)
         TS_MARKER(ExecRecursiveUnion_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeResult.c
+++ b/src/backend/executor/nodeResult.c
@@ -45,6 +45,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeResult.h"
 #include "miscadmin.h"
@@ -188,7 +189,8 @@ ExecInitResult(Result *node, EState *estate, int eflags)
         TS_MARKER(ExecResult_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_MARK | EXEC_FLAG_BACKWARD)) ||

--- a/src/backend/executor/nodeSamplescan.c
+++ b/src/backend/executor/nodeSamplescan.c
@@ -105,7 +105,8 @@ ExecInitSampleScan(SampleScan *node, EState *estate, int eflags)
         TS_MARKER(ExecSampleScan_features, node->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	Assert(outerPlan(node) == NULL);
 	Assert(innerPlan(node) == NULL);

--- a/src/backend/executor/nodeSeqscan.c
+++ b/src/backend/executor/nodeSeqscan.c
@@ -129,7 +129,8 @@ ExecInitSeqScan(SeqScan *node, EState *estate, int eflags)
         TS_MARKER(ExecSeqScan_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/*
 	 * Once upon a time it was possible to have an outerPlan of a SeqScan, but

--- a/src/backend/executor/nodeSetOp.c
+++ b/src/backend/executor/nodeSetOp.c
@@ -45,6 +45,7 @@
 #include "postgres.h"
 
 #include "access/htup_details.h"
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeSetOp.h"
 #include "miscadmin.h"
@@ -489,7 +490,8 @@ ExecInitSetOp(SetOp *node, EState *estate, int eflags)
         TS_MARKER(ExecSetOp_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeSort.c
+++ b/src/backend/executor/nodeSort.c
@@ -16,6 +16,7 @@
 #include "postgres.h"
 
 #include "access/parallel.h"
+#include "access/xact.h"
 #include "executor/execdebug.h"
 #include "executor/nodeSort.h"
 #include "miscadmin.h"
@@ -174,7 +175,8 @@ ExecInitSort(Sort *node, EState *estate, int eflags)
         TS_MARKER(ExecSort_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	SO1_printf("ExecInitSort: %s\n",
 			   "initializing sort node");

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -30,6 +30,7 @@
 #include <math.h>
 
 #include "access/htup_details.h"
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeSubplan.h"
 #include "miscadmin.h"
@@ -108,7 +109,8 @@ Datum pg_attribute_always_inline ExecSubPlan(SubPlanState *node,
             node->planstate->state->es_plannedstmt->queryId,
             node->planstate->plan,
             ChildPlanNodeId(node->planstate->plan->lefttree),
-            ChildPlanNodeId(node->planstate->plan->righttree));
+            ChildPlanNodeId(node->planstate->plan->righttree),
+            GetCurrentStatementStartTimestamp());
   TS_MARKER(ExecSubPlan_begin, node->planstate->plan->plan_node_id);
 
   result = WrappedExecSubPlan(node, econtext, isNull);

--- a/src/backend/executor/nodeSubqueryscan.c
+++ b/src/backend/executor/nodeSubqueryscan.c
@@ -27,6 +27,7 @@
  */
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/execdebug.h"
 #include "executor/nodeSubqueryscan.h"
 #include "tscout/executors.h"
@@ -104,7 +105,8 @@ ExecInitSubqueryScan(SubqueryScan *node, EState *estate, int eflags)
         TS_MARKER(ExecSubqueryScan_features, node->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeTableFuncscan.c
+++ b/src/backend/executor/nodeTableFuncscan.c
@@ -22,6 +22,7 @@
  */
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeTableFuncscan.h"
 #include "executor/tablefunc.h"
@@ -120,7 +121,8 @@ ExecInitTableFuncScan(TableFuncScan *node, EState *estate, int eflags)
         TS_MARKER(ExecTableFuncScan_features, node->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & EXEC_FLAG_MARK));

--- a/src/backend/executor/nodeTidscan.c
+++ b/src/backend/executor/nodeTidscan.c
@@ -508,7 +508,8 @@ ExecInitTidScan(TidScan *node, EState *estate, int eflags)
         TS_MARKER(ExecTidScan_features, node->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/*
 	 * create state structure

--- a/src/backend/executor/nodeUnique.c
+++ b/src/backend/executor/nodeUnique.c
@@ -33,6 +33,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeUnique.h"
 #include "miscadmin.h"
@@ -122,7 +123,8 @@ ExecInitUnique(Unique *node, EState *estate, int eflags)
         TS_MARKER(ExecUnique_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeValuesscan.c
+++ b/src/backend/executor/nodeValuesscan.c
@@ -23,6 +23,7 @@
  */
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/executor.h"
 #include "executor/nodeValuesscan.h"
 #include "jit/jit.h"
@@ -222,7 +223,8 @@ ExecInitValuesScan(ValuesScan *node, EState *estate, int eflags)
         TS_MARKER(ExecValuesScan_features, node->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/*
 	 * ValuesScan should not have any children.

--- a/src/backend/executor/nodeWindowAgg.c
+++ b/src/backend/executor/nodeWindowAgg.c
@@ -34,6 +34,7 @@
 #include "postgres.h"
 
 #include "access/htup_details.h"
+#include "access/xact.h"
 #include "catalog/objectaccess.h"
 #include "catalog/pg_aggregate.h"
 #include "catalog/pg_proc.h"
@@ -2268,7 +2269,8 @@ ExecInitWindowAgg(WindowAgg *node, EState *estate, int eflags)
         TS_MARKER(ExecWindowAgg_features, node->plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->plan.lefttree),
-                  ChildPlanNodeId(node->plan.righttree));
+                  ChildPlanNodeId(node->plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));

--- a/src/backend/executor/nodeWorktablescan.c
+++ b/src/backend/executor/nodeWorktablescan.c
@@ -15,6 +15,7 @@
 
 #include "postgres.h"
 
+#include "access/xact.h"
 #include "executor/execdebug.h"
 #include "executor/nodeWorktablescan.h"
 #include "tscout/executors.h"
@@ -136,7 +137,8 @@ ExecInitWorkTableScan(WorkTableScan *node, EState *estate, int eflags)
         TS_MARKER(ExecWorkTableScan_features, node->scan.plan.plan_node_id,
                   estate->es_plannedstmt->queryId, node,
                   ChildPlanNodeId(node->scan.plan.lefttree),
-                  ChildPlanNodeId(node->scan.plan.righttree));
+                  ChildPlanNodeId(node->scan.plan.righttree),
+                  GetCurrentStatementStartTimestamp());
 
 	/* check for unsupported flags */
 	Assert(!(eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK)));


### PR DESCRIPTION
Similar to #35 yesterday, this adds more metadata to make differencing easier. All the OUs exercised within the same statement should produce the same value. For example, for a pair of
```sql
select count(*) from foo;
```
this yields a plan tree with an Agg node at the root with a single SeqScan child. The resulting CSVs look like:
**ExecAgg.csv**
```
...,statement_timestamp,...
...,694724107067099,...
...,694724120987740,...
```
**ExecSeqScan.csv**
```
...,statement_timestamp,...
...,694724107067099,...
...,694724120987740,...
```
I implemented this using USDT args and doing the function call in user-space.