### PR TITLE
Bugfix: don't accumulate pid

### DIFF
--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -20,6 +20,7 @@ logger = logging.getLogger('tscout')
 
 FLOAT_DOUBLE_NDIGITS = 3
 
+
 @unique
 class BPFType(str, Enum):
     """BPF only has signed and unsigned integers."""
@@ -440,7 +441,8 @@ OU_DEFS = [
      ]),
 ]
 
-# The metrics to be defined for every OU.
+# The metrics to be defined for every OU. If you add anything to these metrics, consider if it should be accumulated
+# across invocations and adjust code related to SUBST_ACCUMULATE as needed.
 OU_METRICS = (
     BPFVariable(name="start_time",
                 c_type=clang.cindex.TypeKind.ULONG,

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -161,7 +161,7 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     metrics_struct = ';\n'.join(defs) + ';'
     collector_c = collector_c.replace("SUBST_METRICS", metrics_struct)
     accumulate = ['lhs->{} += rhs->{}'.format(metric.name, metric.name) for metric in metrics if
-                  metric.name not in ('start_time', 'end_time', 'cpu_id')]  # don't accumulate these 3 metrics
+                  metric.name not in ('start_time', 'end_time', 'pid', 'cpu_id')]  # don't accumulate these metrics
     metrics_accumulate = ';\n'.join(accumulate) + ';'
     collector_c = collector_c.replace("SUBST_ACCUMULATE", metrics_accumulate)
     collector_c = collector_c.replace("SUBST_FIRST_METRIC", metrics[0].name)


### PR DESCRIPTION
I forgot to add `pid` as a metric that shouldn't be accumulated. This can create garbage in that column over multiple invocations of an OU.