### PR TITLE
Remove start_time and end_time metadata fields

### DIFF
--- a/cmudb/tscout/collector.c
+++ b/cmudb/tscout/collector.c
@@ -8,6 +8,7 @@
 
 struct resource_metrics {
   SUBST_METRICS;
+  u64 start_time;  // If more fields are added, adjust the size of the memcpy in the flush marker.
 };
 
 // Each Collector needs a handle to read perf counters
@@ -25,7 +26,5 @@ BPF_HASH(running_metrics, u64, struct resource_metrics, 32);  // TODO(Matt): Thi
 static u64 ou_key(const u32 ou, const s32 ou_instance) { return ((u64)ou) << 32 | ou_instance; }
 
 static void metrics_accumulate(struct resource_metrics *const lhs, const struct resource_metrics *const rhs) {
-  // never overwrite start_time or cpu_id
-  lhs->end_time = rhs->end_time;  // always overwrite end_time
   SUBST_ACCUMULATE;
 }

--- a/cmudb/tscout/collector.c
+++ b/cmudb/tscout/collector.c
@@ -8,7 +8,9 @@
 
 struct resource_metrics {
   SUBST_METRICS;
-  u64 start_time;  // If more fields are added, adjust the size of the memcpy in the flush marker.
+  // The fields below are for bookkeeping/BPF-use only, not to be outputted. If more fields are added, adjust the size
+  // of the memcpy in the flush marker.
+  u64 start_time;  // Used to compute elapsed_us.
 };
 
 // Each Collector needs a handle to read perf counters
@@ -18,7 +20,7 @@ BPF_PERF_ARRAY(cache_references, MAX_CPUS);
 BPF_PERF_ARRAY(cache_misses, MAX_CPUS);
 BPF_PERF_ARRAY(ref_cpu_cycles, MAX_CPUS);
 
-// Stores accumulated metrics, waiting to hit a FEATURES Marker
+// Stores accumulated metrics, waiting to hit a FLUSH Marker
 BPF_HASH(complete_metrics, u64, struct resource_metrics, 32);  // TODO(Matt): Think about this size more
 // Stores a snapshot of the metrics at START Marker, waiting to hit an END Marker
 BPF_HASH(running_metrics, u64, struct resource_metrics, 32);  // TODO(Matt): Think about this size more

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -67,8 +67,8 @@ void SUBST_OU_end(struct pt_regs *ctx) {
   // this is enough to greatly alter measurements, but if it gets any more complicated...
 
   // Collect an end time before probes are complete, converting from nanoseconds to microseconds.
-  metrics->end_time = (bpf_ktime_get_ns() >> 10);
-  metrics->elapsed_us = (metrics->end_time - metrics->start_time);
+  u64 end_time = (bpf_ktime_get_ns() >> 10);
+  metrics->elapsed_us = (end_time - metrics->start_time);
 
   // Probe for CPU counters
   if (!cpu_end(metrics)) {
@@ -159,8 +159,8 @@ void SUBST_OU_flush(struct pt_regs *ctx) {
   // Copy completed features to output struct
   __builtin_memcpy(&(output->SUBST_FIRST_FEATURE), features, sizeof(struct SUBST_OU_features));
 
-  // Copy completed metrics to output struct
-  __builtin_memcpy(&(output->SUBST_FIRST_METRIC), flush_metrics, sizeof(struct resource_metrics));
+  // Copy completed metrics to output struct. We subtract the sizeof start_time since we don't output that field.
+  __builtin_memcpy(&(output->SUBST_FIRST_METRIC), flush_metrics, sizeof(struct resource_metrics) - sizeof(u64));
 
   output->pid = bpf_get_current_pid_tgid();
 

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -444,13 +444,9 @@ OU_DEFS = [
 # The metrics to be defined for every OU. If you add anything to these metrics, consider if it should be accumulated
 # across invocations and adjust code related to SUBST_ACCUMULATE as needed.
 OU_METRICS = (
-    BPFVariable(name="start_time",
+    BPFVariable(name="cpu_cycles",
                 c_type=clang.cindex.TypeKind.ULONG,
                 alignment=8),
-    BPFVariable(name="end_time",
-                c_type=clang.cindex.TypeKind.ULONG),
-    BPFVariable(name="cpu_cycles",
-                c_type=clang.cindex.TypeKind.ULONG),
     BPFVariable(name="instructions",
                 c_type=clang.cindex.TypeKind.ULONG),
     BPFVariable(name="cache_references",

--- a/cmudb/tscout/tscout.py
+++ b/cmudb/tscout/tscout.py
@@ -161,7 +161,7 @@ def collector(collector_flags, ou_processor_queues, pid, socket_fd):
     metrics_struct = ';\n'.join(defs) + ';'
     collector_c = collector_c.replace("SUBST_METRICS", metrics_struct)
     accumulate = ['lhs->{} += rhs->{}'.format(metric.name, metric.name) for metric in metrics if
-                  metric.name not in ('start_time', 'end_time', 'pid', 'cpu_id')]  # don't accumulate these metrics
+                  metric.name not in ('pid', 'cpu_id')]  # don't accumulate these metrics
     metrics_accumulate = ';\n'.join(accumulate) + ';'
     collector_c = collector_c.replace("SUBST_ACCUMULATE", metrics_accumulate)
     collector_c = collector_c.replace("SUBST_FIRST_METRIC", metrics[0].name)


### PR DESCRIPTION
We now have other metadata to do differencing (#35, #37).