### PR TITLE
Revert EXPLAIN Xs (#41)

### DIFF
--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -107,9 +107,9 @@ void SUBST_OU_features(struct pt_regs *ctx) {
   memset(features, 0, sizeof(struct SUBST_OU_features));
 
   // Copy features from USDT arg (pointer to features struct in NoisePage) to features struct.
-  SUBST_READARGS
+  SUBST_READARGS;
 
-  // Store the features, waiting for BEGIN, END, and FLUSH.
+  // Store the features, waiting for BEGIN(s), END(s), and FLUSH.
   s32 ou_instance = 0;
   bpf_usdt_readarg(1, ctx, &ou_instance);
   SUBST_OU_complete_features.update(&ou_instance, features);
@@ -126,7 +126,7 @@ void SUBST_OU_flush(struct pt_regs *ctx) {
   bpf_usdt_readarg(1, ctx, &ou_instance);
   u64 key = ou_key(SUBST_INDEX, ou_instance);
 
-  // Retrieve the features
+  // Retrieve the features.
   struct SUBST_OU_features *features = NULL;
   features = SUBST_OU_complete_features.lookup(&ou_instance);
   if (features == NULL) {
@@ -150,18 +150,18 @@ void SUBST_OU_flush(struct pt_regs *ctx) {
     bpf_trace_printk("Fatal error. Scratch array lookup failed.");
     return;
   }
-  // Zero initialize output struct for features and metrics
+  // Zero initialize output struct for features and metrics.
   memset(output, 0, sizeof(struct SUBST_OU_output));
+
+  // Copy features to output struct.
+  __builtin_memcpy(&(output->SUBST_FIRST_FEATURE), features, sizeof(struct SUBST_OU_features));
+
+  // Copy completed metrics to output struct.
+  __builtin_memcpy(&(output->SUBST_FIRST_METRIC), flush_metrics, sizeof(struct resource_metrics));
 
   // Set the index of this SUBST_OU so the Collector knows which Processor to send this data point to.
   output->ou_index = SUBST_INDEX;
-
-  // Copy completed features to output struct
-  __builtin_memcpy(&(output->SUBST_FIRST_FEATURE), features, sizeof(struct SUBST_OU_features));
-
-  // Copy completed metrics to output struct
-  __builtin_memcpy(&(output->SUBST_FIRST_METRIC), flush_metrics, sizeof(struct resource_metrics));
-
+  // Set remaining metadata.
   output->pid = bpf_get_current_pid_tgid();
 
   // Send output struct to userspace via subsystem's perf ring buffer.

--- a/cmudb/tscout/markers.c
+++ b/cmudb/tscout/markers.c
@@ -107,9 +107,9 @@ void SUBST_OU_features(struct pt_regs *ctx) {
   memset(features, 0, sizeof(struct SUBST_OU_features));
 
   // Copy features from USDT arg (pointer to features struct in NoisePage) to features struct.
-  SUBST_READARGS;
+  SUBST_READARGS
 
-  // Store the features, waiting for BEGIN(s), END(s), and FLUSH.
+  // Store the features, waiting for BEGIN, END, and FLUSH.
   s32 ou_instance = 0;
   bpf_usdt_readarg(1, ctx, &ou_instance);
   SUBST_OU_complete_features.update(&ou_instance, features);
@@ -126,11 +126,19 @@ void SUBST_OU_flush(struct pt_regs *ctx) {
   bpf_usdt_readarg(1, ctx, &ou_instance);
   u64 key = ou_key(SUBST_INDEX, ou_instance);
 
-  // Retrieve the features.
+  // Retrieve the features
   struct SUBST_OU_features *features = NULL;
   features = SUBST_OU_complete_features.lookup(&ou_instance);
   if (features == NULL) {
     // We don't have any features for this data point.
+    SUBST_OU_reset(ou_instance);
+    return;
+  }
+
+  struct resource_metrics *flush_metrics = NULL;
+  flush_metrics = complete_metrics.lookup(&key);
+  if (flush_metrics == NULL) {
+    // We don't have any metrics for this data point.
     SUBST_OU_reset(ou_instance);
     return;
   }
@@ -142,24 +150,18 @@ void SUBST_OU_flush(struct pt_regs *ctx) {
     bpf_trace_printk("Fatal error. Scratch array lookup failed.");
     return;
   }
-  // Zero initialize output struct for features and metrics.
+  // Zero initialize output struct for features and metrics
   memset(output, 0, sizeof(struct SUBST_OU_output));
-
-  // Copy features to output struct.
-  __builtin_memcpy(&(output->SUBST_FIRST_FEATURE), features, sizeof(struct SUBST_OU_features));
-
-  struct resource_metrics *flush_metrics = NULL;
-  flush_metrics = complete_metrics.lookup(&key);
-  if (flush_metrics) {
-    // We have metrics for this data point.  Copy completed metrics to output struct.
-    // TODO(Matt): We could add an arg at flush markers to be more strict with the state machine about whether we expect
-    // metrics with this flush marker.
-    __builtin_memcpy(&(output->SUBST_FIRST_METRIC), flush_metrics, sizeof(struct resource_metrics));
-  }
 
   // Set the index of this SUBST_OU so the Collector knows which Processor to send this data point to.
   output->ou_index = SUBST_INDEX;
-  // Set remaining metadata.
+
+  // Copy completed features to output struct
+  __builtin_memcpy(&(output->SUBST_FIRST_FEATURE), features, sizeof(struct SUBST_OU_features));
+
+  // Copy completed metrics to output struct
+  __builtin_memcpy(&(output->SUBST_FIRST_METRIC), flush_metrics, sizeof(struct resource_metrics));
+
   output->pid = bpf_get_current_pid_tgid();
 
   // Send output struct to userspace via subsystem's perf ring buffer.

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -131,9 +131,7 @@ class Feature:
     bpf_tuple: Tuple[BPFVariable] = None
 
 
-# Internally, Postgres stores query_id as uint64. However, EXPLAIN VERBOSE and pg_stat_statements both represent
-# query_id as BIGINT so TScout stores it as int64 to match this representation.
-QUERY_ID = Feature("QueryId", readarg_p=False, bpf_tuple=(BPFVariable("query_id", clang.cindex.TypeKind.LONG),))
+QUERY_ID = Feature("QueryId", readarg_p=False, bpf_tuple=(BPFVariable("query_id", clang.cindex.TypeKind.ULONG),))
 LEFT_CHILD_NODE_ID = Feature("left_child_plan_node_id", readarg_p=False,
                              bpf_tuple=(BPFVariable("left_child_plan_node_id", clang.cindex.TypeKind.INT),))
 RIGHT_CHILD_NODE_ID = Feature("right_child_plan_node_id", readarg_p=False,

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -131,7 +131,9 @@ class Feature:
     bpf_tuple: Tuple[BPFVariable] = None
 
 
-QUERY_ID = Feature("QueryId", readarg_p=False, bpf_tuple=(BPFVariable("query_id", clang.cindex.TypeKind.ULONG),))
+# Internally, Postgres stores query_id as uint64. However, EXPLAIN VERBOSE and pg_stat_statements both represent
+# query_id as BIGINT so TScout stores it as int64 to match this representation.
+QUERY_ID = Feature("QueryId", readarg_p=False, bpf_tuple=(BPFVariable("query_id", clang.cindex.TypeKind.LONG),))
 LEFT_CHILD_NODE_ID = Feature("left_child_plan_node_id", readarg_p=False,
                              bpf_tuple=(BPFVariable("left_child_plan_node_id", clang.cindex.TypeKind.INT),))
 RIGHT_CHILD_NODE_ID = Feature("right_child_plan_node_id", readarg_p=False,

--- a/src/backend/commands/explain.c
+++ b/src/backend/commands/explain.c
@@ -29,7 +29,6 @@
 #include "rewrite/rewriteHandler.h"
 #include "storage/bufmgr.h"
 #include "tcop/tcopprot.h"
-#include "tscout/executors.h"
 #include "utils/builtins.h"
 #include "utils/guc_tables.h"
 #include "utils/json.h"
@@ -1165,15 +1164,12 @@ ExplainNode(PlanState *planstate, List *ancestors,
 	switch (nodeTag(plan))
 	{
 		case T_Result:
-                        TS_EXPLAIN(Result);
 			pname = sname = "Result";
 			break;
 		case T_ProjectSet:
-                        TS_EXPLAIN(ProjectSet);
 			pname = sname = "ProjectSet";
 			break;
 		case T_ModifyTable:
-                        TS_EXPLAIN(ModifyTable);
 			sname = "ModifyTable";
 			switch (((ModifyTable *) plan)->operation)
 			{
@@ -1192,15 +1188,12 @@ ExplainNode(PlanState *planstate, List *ancestors,
 			}
 			break;
 		case T_Append:
-                        TS_EXPLAIN(Append);
 			pname = sname = "Append";
 			break;
 		case T_MergeAppend:
-                        TS_EXPLAIN(MergeAppend);
 			pname = sname = "Merge Append";
 			break;
 		case T_RecursiveUnion:
-                        TS_EXPLAIN(RecursiveUnion);
 			pname = sname = "Recursive Union";
 			break;
 		case T_BitmapAnd:
@@ -1210,41 +1203,32 @@ ExplainNode(PlanState *planstate, List *ancestors,
 			pname = sname = "BitmapOr";
 			break;
 		case T_NestLoop:
-                        TS_EXPLAIN(NestLoop);
 			pname = sname = "Nested Loop";
 			break;
 		case T_MergeJoin:
-                        TS_EXPLAIN(MergeJoin);
 			pname = "Merge";	/* "Join" gets added by jointype switch */
 			sname = "Merge Join";
 			break;
 		case T_HashJoin:
-                        TS_EXPLAIN(HashJoin);
 			pname = "Hash";		/* "Join" gets added by jointype switch */
 			sname = "Hash Join";
 			break;
 		case T_SeqScan:
-                        TS_EXPLAIN(SeqScan);
 			pname = sname = "Seq Scan";
 			break;
 		case T_SampleScan:
-                        TS_EXPLAIN(SampleScan);
 			pname = sname = "Sample Scan";
 			break;
 		case T_Gather:
-                        TS_EXPLAIN(Gather);
 			pname = sname = "Gather";
 			break;
 		case T_GatherMerge:
-                        TS_EXPLAIN(GatherMerge);
 			pname = sname = "Gather Merge";
 			break;
 		case T_IndexScan:
-                        TS_EXPLAIN(IndexScan);
 			pname = sname = "Index Scan";
 			break;
 		case T_IndexOnlyScan:
-                        TS_EXPLAIN(IndexOnlyScan);
 			pname = sname = "Index Only Scan";
 			break;
 		case T_BitmapIndexScan:
@@ -1254,42 +1238,33 @@ ExplainNode(PlanState *planstate, List *ancestors,
 			pname = sname = "Bitmap Heap Scan";
 			break;
 		case T_TidScan:
-                        TS_EXPLAIN(TidScan);
 			pname = sname = "Tid Scan";
 			break;
 		case T_TidRangeScan:
 			pname = sname = "Tid Range Scan";
 			break;
 		case T_SubqueryScan:
-                        TS_EXPLAIN(SubqueryScan);
 			pname = sname = "Subquery Scan";
 			break;
 		case T_FunctionScan:
-                        TS_EXPLAIN(FunctionScan);
 			pname = sname = "Function Scan";
 			break;
 		case T_TableFuncScan:
-                        TS_EXPLAIN(TableFuncScan);
 			pname = sname = "Table Function Scan";
 			break;
 		case T_ValuesScan:
-                        TS_EXPLAIN(ValuesScan);
 			pname = sname = "Values Scan";
 			break;
 		case T_CteScan:
-                        TS_EXPLAIN(CteScan);
 			pname = sname = "CTE Scan";
 			break;
 		case T_NamedTuplestoreScan:
-                        TS_EXPLAIN(NamedTuplestoreScan);
 			pname = sname = "Named Tuplestore Scan";
 			break;
 		case T_WorkTableScan:
-                        TS_EXPLAIN(WorkTableScan);
 			pname = sname = "WorkTable Scan";
 			break;
 		case T_ForeignScan:
-                        TS_EXPLAIN(ForeignScan);
 			sname = "Foreign Scan";
 			switch (((ForeignScan *) plan)->operation)
 			{
@@ -1315,7 +1290,6 @@ ExplainNode(PlanState *planstate, List *ancestors,
 			}
 			break;
 		case T_CustomScan:
-                        TS_EXPLAIN(CustomScan);
 			sname = "Custom Scan";
 			custom_name = ((CustomScan *) plan)->methods->CustomName;
 			if (custom_name)
@@ -1324,26 +1298,21 @@ ExplainNode(PlanState *planstate, List *ancestors,
 				pname = sname;
 			break;
 		case T_Material:
-                        TS_EXPLAIN(Material);
 			pname = sname = "Materialize";
 			break;
 		case T_Memoize:
 			pname = sname = "Memoize";
 			break;
 		case T_Sort:
-                        TS_EXPLAIN(Sort);
 			pname = sname = "Sort";
 			break;
 		case T_IncrementalSort:
-                        TS_EXPLAIN(IncrementalSort);
 			pname = sname = "Incremental Sort";
 			break;
 		case T_Group:
-                        TS_EXPLAIN(Group);
 			pname = sname = "Group";
 			break;
 		case T_Agg:
-                        TS_EXPLAIN(Agg);
 			{
 				Agg		   *agg = (Agg *) plan;
 
@@ -1387,15 +1356,12 @@ ExplainNode(PlanState *planstate, List *ancestors,
 			}
 			break;
 		case T_WindowAgg:
-                        TS_EXPLAIN(WindowAgg);
 			pname = sname = "WindowAgg";
 			break;
 		case T_Unique:
-                        TS_EXPLAIN(Unique);
 			pname = sname = "Unique";
 			break;
 		case T_SetOp:
-                        TS_EXPLAIN(SetOp);
 			sname = "SetOp";
 			switch (((SetOp *) plan)->strategy)
 			{
@@ -1414,15 +1380,12 @@ ExplainNode(PlanState *planstate, List *ancestors,
 			}
 			break;
 		case T_LockRows:
-                        TS_EXPLAIN(LockRows);
 			pname = sname = "LockRows";
 			break;
 		case T_Limit:
-                        TS_EXPLAIN(Limit);
 			pname = sname = "Limit";
 			break;
 		case T_Hash:
-                        TS_EXPLAIN(Hash);
 			pname = sname = "Hash";
 			break;
 		default:

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -7,13 +7,6 @@ static int ChildPlanNodeId(const struct Plan *const child_plan_node) {
   return child_plan_node ? child_plan_node->plan_node_id : -1;
 }
 
-#define TS_EXPLAIN(node_type)                                                  \
-  TS_MARKER(Exec##node_type##_features, plan->plan_node_id,                    \
-            es->pstmt->queryId, plan, ChildPlanNodeId(plan->lefttree),         \
-            ChildPlanNodeId(plan->righttree),                                  \
-            GetCurrentStatementStartTimestamp());                              \
-  TS_MARKER(Exec##node_type##_flush, plan->plan_node_id);
-
 /*
  * Wrapper to add TScout markers to an executor. In the executor file, rename
  * the current Exec<blah> function to WrappedExec<blah> and then add


### PR DESCRIPTION
Reverting the EXPLAIN-related changes since we're pursuing an extension instead. Keeping the documentation improvements and query_id change from #41.