### PR TITLE
Add BitmapAnd and Hash (table build for Hashjoin) OUs

### DIFF
--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -169,6 +169,14 @@ OU_DEFS = [
          RIGHT_CHILD_NODE_ID,
          STATEMENT_TIMESTAMP
      ]),
+    ("ExecBitmapAnd",
+     [
+         QUERY_ID,
+         Feature("BitmapAnd"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
+     ]),
     ("ExecCteScan",
      [
          QUERY_ID,
@@ -221,6 +229,14 @@ OU_DEFS = [
      [
          QUERY_ID,
          Feature("Group"),
+         LEFT_CHILD_NODE_ID,
+         RIGHT_CHILD_NODE_ID,
+         STATEMENT_TIMESTAMP
+     ]),
+    ("ExecHash",
+     [
+         QUERY_ID,
+         Feature("Hash"),
          LEFT_CHILD_NODE_ID,
          RIGHT_CHILD_NODE_ID,
          STATEMENT_TIMESTAMP

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -12,11 +12,13 @@ static int ChildPlanNodeId(const struct Plan *const child_plan_node) {
  * the current Exec<blah> function to WrappedExec<blah> and then add
  * TS_EXECUTOR_WRAPPER<blah> beneath it. See src/backend/executors for examples.
  *
- * There is a small list of executors that cannot use this macro due to function
- * signature differences. If the macro below changes, be sure to update those
- * executors as well. The current list is:
+ * Some executors cannot use this macro due to function signature differences.
+ * If the macro below changes, be sure to update those executors as well. The
+ * current list is:
  *
+ * src/backend/executors/nodeBitmapAnd.c
  * src/backend/executors/nodeSubplan.c
+ * src/backend/executors/nodeHash.c
  * src/backend/executors/nodeHashJoin.c
  */
 #define TS_EXECUTOR_WRAPPER(node_type)                                         \


### PR DESCRIPTION
nodeHash.c's code (entry and exit points) was intimidating when first adding TS, so we punted on that OU. However, we need it to perform differencing correctly with hash joins. An easy test query is:
```sql
select * from information_schema.tables;
```
which would show missing plan nodes for hash table build. We can now construct the full query tree.

I also added BitmapAnd while I was at it. It would be helpful to follow this PR adding any other missing OUs.