### PR TITLE
TScout: memory bytes

### DIFF
--- a/cmudb/extensions/hutch/main.c
+++ b/cmudb/extensions/hutch/main.c
@@ -8,12 +8,11 @@
 
 #include "commands/createas.h"
 #include "commands/explain.h"
+#include "operating_unit_features.h"
 #include "optimizer/planner.h"
 #include "parser/parsetree.h"
-#include "utils/builtins.h"
-
 #include "tscout/marker.h"
-#include "operating_unit_features.h"
+#include "utils/builtins.h"
 
 PG_MODULE_MAGIC;
 void _PG_init(void);

--- a/src/backend/executor/nodeBitmapAnd.c
+++ b/src/backend/executor/nodeBitmapAnd.c
@@ -173,11 +173,11 @@ Node *
 MultiExecBitmapAnd(BitmapAndState *node) {
   if (tscout_executor_running) {
     Node *result;
-    TS_MARKER(ExecBitmapAnd_begin, node->ps.plan->plan_node_id);
+    TS_MARKER(ExecBitmapAnd_begin, node->ps.plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
 
     result = WrappedMultiExecBitmapAnd(node);
 
-    TS_MARKER(ExecBitmapAnd_end, node->ps.plan->plan_node_id);
+    TS_MARKER(ExecBitmapAnd_end, node->ps.plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
     return result;
   }
   return WrappedMultiExecBitmapAnd(node);

--- a/src/backend/executor/nodeBitmapIndexscan.c
+++ b/src/backend/executor/nodeBitmapIndexscan.c
@@ -126,11 +126,11 @@ Node *
 MultiExecBitmapIndexScan(BitmapIndexScanState *node) {
   if (tscout_executor_running) {
     Node *result;
-    TS_MARKER(ExecBitmapIndexScan_begin, node->ss.ps.plan->plan_node_id);
+    TS_MARKER(ExecBitmapIndexScan_begin, node->ss.ps.plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
 
     result = WrappedMultiExecBitmapIndexScan(node);
 
-    TS_MARKER(ExecBitmapIndexScan_end, node->ss.ps.plan->plan_node_id);
+    TS_MARKER(ExecBitmapIndexScan_end, node->ss.ps.plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
     return result;
   }
   return WrappedMultiExecBitmapIndexScan(node);

--- a/src/backend/executor/nodeBitmapOr.c
+++ b/src/backend/executor/nodeBitmapOr.c
@@ -191,11 +191,11 @@ Node *
 MultiExecBitmapOr(BitmapOrState *node) {
   if (tscout_executor_running) {
     Node *result;
-    TS_MARKER(ExecBitmapOr_begin, node->ps.plan->plan_node_id);
+    TS_MARKER(ExecBitmapOr_begin, node->ps.plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
 
     result = WrappedMultiExecBitmapOr(node);
 
-    TS_MARKER(ExecBitmapOr_end, node->ps.plan->plan_node_id);
+    TS_MARKER(ExecBitmapOr_end, node->ps.plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
     return result;
   }
   return WrappedMultiExecBitmapOr(node);

--- a/src/backend/executor/nodeHash.c
+++ b/src/backend/executor/nodeHash.c
@@ -133,11 +133,11 @@ Node *
 MultiExecHash(HashState *node) {
   if (tscout_executor_running) {
     Node *result;
-    TS_MARKER(ExecHash_begin, node->ps.plan->plan_node_id);
+    TS_MARKER(ExecHash_begin, node->ps.plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
 
     result = WrappedMultiExecHash(node);
 
-    TS_MARKER(ExecHash_end, node->ps.plan->plan_node_id);
+    TS_MARKER(ExecHash_end, node->ps.plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
     return result;
   }
   return WrappedMultiExecHash(node);

--- a/src/backend/executor/nodeHashjoin.c
+++ b/src/backend/executor/nodeHashjoin.c
@@ -580,11 +580,11 @@ WrappedExecHashJoinImpl(PlanState *pstate, bool parallel)
 static pg_attribute_always_inline TupleTableSlot *
 ExecHashJoinImpl(PlanState *pstate, bool parallel) {
   TupleTableSlot *result;
-  TS_MARKER(ExecHashJoinImpl_begin, pstate->plan->plan_node_id);
+  TS_MARKER(ExecHashJoinImpl_begin, pstate->plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
 
   result = WrappedExecHashJoinImpl(pstate, parallel);
 
-  TS_MARKER(ExecHashJoinImpl_end, pstate->plan->plan_node_id);
+  TS_MARKER(ExecHashJoinImpl_end, pstate->plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
 
   return result;
 }

--- a/src/backend/executor/nodeSubplan.c
+++ b/src/backend/executor/nodeSubplan.c
@@ -109,11 +109,11 @@ Datum pg_attribute_always_inline ExecSubPlan(SubPlanState *node,
               node->planstate->state->es_plannedstmt->queryId, node->planstate->plan,
               ChildPlanNodeId(node->planstate->plan->lefttree), ChildPlanNodeId(node->planstate->plan->righttree),
               GetCurrentStatementStartTimestamp());
-    TS_MARKER(ExecSubPlan_begin, node->planstate->plan->plan_node_id);
+    TS_MARKER(ExecSubPlan_begin, node->planstate->plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
 
     result = WrappedExecSubPlan(node, econtext, isNull);
 
-    TS_MARKER(ExecSubPlan_end, true, node->planstate->plan->plan_node_id);
+    TS_MARKER(ExecSubPlan_end, true, node->planstate->plan->plan_node_id, MemoryContextMemAllocated(TopTransactionContext, true));
     TS_MARKER(ExecSubPlan_flush, node->planstate->plan->plan_node_id);
     return result;
   }

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -38,18 +38,18 @@ static int ChildPlanNodeId(const struct Plan *const child_plan_node) {
  * src/backend/executors/nodeHash.c
  * src/backend/executors/nodeHashjoin.c
  */
-#define TS_EXECUTOR_WRAPPER(node_type)                                           \
-  static TupleTableSlot *Exec##node_type(PlanState *pstate) {                    \
-    if (tscout_executor_running) {                                               \
-      TupleTableSlot *result;                                                    \
-      TS_MARKER(Exec##node_type##_begin, pstate->plan->plan_node_id,             \
+#define TS_EXECUTOR_WRAPPER(node_type)                                   \
+  static TupleTableSlot *Exec##node_type(PlanState *pstate) {            \
+    if (tscout_executor_running) {                                       \
+      TupleTableSlot *result;                                            \
+      TS_MARKER(Exec##node_type##_begin, pstate->plan->plan_node_id,     \
                 MemoryContextMemAllocated(TopTransactionContext, true)); \
-                                                                                 \
-      result = WrappedExec##node_type(pstate);                                   \
-                                                                                 \
-      TS_MARKER(Exec##node_type##_end, pstate->plan->plan_node_id,               \
+                                                                         \
+      result = WrappedExec##node_type(pstate);                           \
+                                                                         \
+      TS_MARKER(Exec##node_type##_end, pstate->plan->plan_node_id,       \
                 MemoryContextMemAllocated(TopTransactionContext, true)); \
-      return result;                                                             \
-    }                                                                            \
-    return WrappedExec##node_type(pstate);                                       \
+      return result;                                                     \
+    }                                                                    \
+    return WrappedExec##node_type(pstate);                               \
   }

--- a/src/include/tscout/executors.h
+++ b/src/include/tscout/executors.h
@@ -38,18 +38,17 @@ static int ChildPlanNodeId(const struct Plan *const child_plan_node) {
  * src/backend/executors/nodeHash.c
  * src/backend/executors/nodeHashjoin.c
  */
-#define TS_EXECUTOR_WRAPPER(node_type)                                   \
-  static TupleTableSlot *Exec##node_type(PlanState *pstate) {            \
-    if (tscout_executor_running) {                                       \
-      TupleTableSlot *result;                                            \
-      TS_MARKER(Exec##node_type##_begin, pstate->plan->plan_node_id,     \
-                MemoryContextMemAllocated(TopTransactionContext, true)); \
-                                                                         \
-      result = WrappedExec##node_type(pstate);                           \
-                                                                         \
-      TS_MARKER(Exec##node_type##_end, pstate->plan->plan_node_id,       \
-                MemoryContextMemAllocated(TopTransactionContext, true)); \
-      return result;                                                     \
-    }                                                                    \
-    return WrappedExec##node_type(pstate);                               \
+#define TS_EXECUTOR_WRAPPER(node_type)                                                                                 \
+  static TupleTableSlot *Exec##node_type(PlanState *pstate) {                                                          \
+    if (tscout_executor_running) {                                                                                     \
+      TupleTableSlot *result;                                                                                          \
+      TS_MARKER(Exec##node_type##_begin, pstate->plan->plan_node_id,                                                   \
+                MemoryContextMemAllocated(TopMemoryContext, true));                                                    \
+                                                                                                                       \
+      result = WrappedExec##node_type(pstate);                                                                         \
+                                                                                                                       \
+      TS_MARKER(Exec##node_type##_end, pstate->plan->plan_node_id, MemoryContextMemAllocated(TopMemoryContext, true)); \
+      return result;                                                                                                   \
+    }                                                                                                                  \
+    return WrappedExec##node_type(pstate);                                                                             \
   }


### PR DESCRIPTION
We punted on defining the user space probe for memory bytes (i.e., `memory_bytes` is always 0 right now). This implementation uses the `TopMemoryContext` in postgres and computes the difference in allocated memory between `BEGIN` and `END` markers. We should discuss if this is the right context, and investigate how much walking the `MemoryContext` tree with this frequency affects performance.