### PR TITLE
Fix warning in tscout/sampling.h. Add `-s` arg to make.

### DIFF
--- a/dodos/noisepage.py
+++ b/dodos/noisepage.py
@@ -48,7 +48,7 @@ def task_np_clean():
     """
     return {
         "actions": [
-            "make -j clean",
+            "make -j -s clean",
         ],
         "file_dep": [ARTIFACT_config_log],
         "verbosity": VERBOSITY_DEFAULT,
@@ -62,7 +62,7 @@ def task_np_build():
     """
     return {
         "actions": [
-            "make -j install-world-bin",
+            "make -j -s install-world-bin",
         ],
         "file_dep": [ARTIFACT_config_log],
         "targets": [ARTIFACT_postgres],

--- a/src/include/tscout/sampling.h
+++ b/src/include/tscout/sampling.h
@@ -11,4 +11,4 @@ extern double tscout_executor_sampling_rate;  // guc variable (e.g., SET tscout_
  * Called at the start of query execution. For the duration of query execution, check tscout_executor_running before
  * each TScout interaction to see if this query is being tracked.
  */
-void TScoutExecutorSample();
+void TScoutExecutorSample(void);


### PR DESCRIPTION
There's a warning tucked in the thousands of lines of `make` output that a function without args needs to have its prototype explicitly have args of `(void)`. This fixes that warning, and adds the `-s` arg to make so we don't see output that isn't exceptional.