### PR TITLE
Fix `PYTHONPATH` for `hutch_install`.

### DIFF
--- a/dodos/hutch.py
+++ b/dodos/hutch.py
@@ -13,7 +13,7 @@ def task_hutch_install():
         "actions": [
             lambda: os.chdir("cmudb/extensions/hutch/"),
             # Generate the necessary features.
-            "sudo PYTHONPATH=../..:$PYTHONPATH python3 tscout_feature_gen.py",
+            "sudo PYTHONPATH=../../tscout:$PYTHONPATH python3 tscout_feature_gen.py",
             # Install the extension into the default build directory's PostgreSQL.
             # Note that the PG_CONFIG env var can be specified to override which
             # PostgreSQL the extension gets installed into.


### PR DESCRIPTION
Fix `PYTHONPATH` for `hutch_install`.

The `tscout` folder has to be in the `PYTHONPATH`.

---

I think I made a typo when copying over my initial bash scripts.
Verified that `ci_clean_slate`, `np_build`, `hutch_install` sequence works now.
