### PR TITLE
Hutch/TScout Bandaid

### DIFF
--- a/cmudb/extensions/hutch/main.c
+++ b/cmudb/extensions/hutch/main.c
@@ -22,7 +22,7 @@ static void ExplainOneQueryWrapper(Query *query, int cursorOptions, IntoClause *
                                    const char *queryString, ParamListInfo params, QueryEnvironment *queryEnv);
 static void WalkPlan(Plan *plan, ExplainState *es);
 static void ExplainFeatures(Plan *node, ExplainState *es);
-static size_t GetFieldSize(c_type type);
+static size_t GetFieldSize(c_type type, int padding);
 static const char *GetNodeType(Plan *node);
 static const char *GetOperationType(Plan *node);
 
@@ -119,9 +119,10 @@ static void ExplainOneQueryWrapper(Query *query, int cursorOptions, IntoClause *
  * @brief Fetch the size of the field.
  *
  * @param type (c_type) - The C field type.
+ * @param padding (int) - Size of padding if a padding field.
  * @return size_t - Size of the field on the machine.
  */
-size_t GetFieldSize(c_type type) {
+size_t GetFieldSize(c_type type, int padding) {
   switch (type) {
     case T_BOOL:
       return sizeof(bool);
@@ -140,6 +141,8 @@ size_t GetFieldSize(c_type type) {
     case T_PTR:
     case T_LIST_PTR:
       return sizeof(void *);
+    case T_PADDING:
+      return padding;
     default:
       break;
   }
@@ -361,8 +364,8 @@ static void ExplainFeatures(Plan *node, ExplainState *es) {
   }
 
   for (i = 0; i < num_fields; i++) {
-    field_size = GetFieldSize(fields[i].type);
-    next_field_size = i < num_fields - 1 ? GetFieldSize(fields[i + 1].type) : 8;
+    field_size = GetFieldSize(fields[i].type, fields[i].padding);
+    next_field_size = i < num_fields - 1 ? GetFieldSize(fields[i + 1].type, fields[i + 1].padding) : 8;
 
     switch (fields[i].type) {
       case T_BOOL:

--- a/cmudb/extensions/hutch/main.c
+++ b/cmudb/extensions/hutch/main.c
@@ -22,7 +22,7 @@ static void ExplainOneQueryWrapper(Query *query, int cursorOptions, IntoClause *
                                    const char *queryString, ParamListInfo params, QueryEnvironment *queryEnv);
 static void WalkPlan(Plan *plan, ExplainState *es);
 static void ExplainFeatures(Plan *node, ExplainState *es);
-static size_t GetFieldSize(c_type type, int padding);
+static size_t GetFieldSize(c_type type, const uint32_t padding);
 static const char *GetNodeType(Plan *node);
 static const char *GetOperationType(Plan *node);
 
@@ -119,10 +119,10 @@ static void ExplainOneQueryWrapper(Query *query, int cursorOptions, IntoClause *
  * @brief Fetch the size of the field.
  *
  * @param type (c_type) - The C field type.
- * @param padding (int) - Size of padding if a padding field.
+ * @param padding (uint32_t) - Size of padding if a padding field.
  * @return size_t - Size of the field on the machine.
  */
-size_t GetFieldSize(c_type type, int padding) {
+size_t GetFieldSize(c_type type, const uint32_t padding) {
   switch (type) {
     case T_BOOL:
       return sizeof(bool);

--- a/cmudb/extensions/hutch/operating_unit_codegen.c
+++ b/cmudb/extensions/hutch/operating_unit_codegen.c
@@ -16,6 +16,7 @@ typedef enum c_type {
   T_PTR,
   T_UNKNOWN,
   T_LIST_PTR,  // This is not a long-term solution if we start defining more Reagents.
+  T_PADDING,
 } c_type;
 
 /**
@@ -26,6 +27,7 @@ typedef enum c_type {
 typedef struct field {
   c_type type;
   char *name;
+  int padding;
 } field;
 
 /**

--- a/cmudb/tscout/model.py
+++ b/cmudb/tscout/model.py
@@ -44,6 +44,18 @@ class BPFVariable:
     pg_type: str = None  # Some BPFVariables don't originate from Postgres (e.g., metrics and metadata) so default None
     alignment: int = None  # Non-None for the first field of a struct, using alignment value of the struct.
 
+    # Indicates whether this field is a padding field used to keep user-space/kernel-space structs in alignment.
+    is_padding: bool = False
+    # Non-None if this field is a padding field. This controls the size of the padding field.
+    padding_field_size: int = None
+
+    def type_string(self):
+        if self.is_padding:
+            assert self.padding_field_size is not None, f"padding_field_size must be set for padding field {self.name}"
+            return f"char {self.name}[{self.padding_field_size}];"
+
+        return f"{CLANG_TO_BPF[self.c_type]} {self.name}{self.alignment_string()};"
+
     def alignment_string(self):
         return f" __attribute__ ((aligned ({self.alignment})))" if self.alignment is not None else ""
 
@@ -63,7 +75,7 @@ class BPFVariable:
             clang.cindex.TypeKind.INCOMPLETEARRAY,
             clang.cindex.TypeKind.CONSTANTARRAY,
         ]
-        return self.c_type not in suppressed
+        return self.c_type not in suppressed and not self.is_padding
 
     def serialize(self, output_event):
         """
@@ -651,7 +663,7 @@ def struct_decl_for_fields(name, bpf_tuple):
     assert len(bpf_tuple) > 0, "We should have some fields in this struct."
     decl = [f"struct DECL_{name}", "{"]
     for column in bpf_tuple:
-        decl.append(f"{CLANG_TO_BPF[column.c_type]} {column.name}{column.alignment_string()};")
+        decl.append(column.type_string())
     decl.append("};\n")
     return "\n".join(decl)
 
@@ -702,15 +714,11 @@ class OperatingUnit:
                 assert len(feature.bpf_tuple) >= 1, "We should have some fields in this struct."
                 # Add all the struct's fields, sticking the original struct's alignment value on the first attribute.
                 for column in feature.bpf_tuple:
-                    struct_def = struct_def + (
-                        f"{CLANG_TO_BPF[column.c_type]} {column.name}{column.alignment_string()};\n"
-                    )
+                    struct_def = struct_def + (column.type_string() + "\n")
             else:
                 # It's a single stack-allocated argument that we can read directly.
                 assert len(feature.bpf_tuple) == 1, "How can something not using readarg_p have multiple fields?"
-                struct_def = struct_def + (
-                    f"{CLANG_TO_BPF[feature.bpf_tuple[0].c_type]} {feature.bpf_tuple[0].name};\n"
-                )
+                struct_def = struct_def + (feature.bpf_tuple[0].type_string() + "\n")
 
         return struct_def
 
@@ -779,6 +787,9 @@ class Model:
                             else REAGENTS[field.pg_type].return_type,
                             pg_type=field.pg_type,
                             alignment=field.alignment if i == 0 else None,
+                            # Propagate information about the padding.
+                            is_padding=field.is_padding,
+                            padding_field_size=field.field_size if field.is_padding else None,
                         )
                     )
                 except KeyError as e:


### PR DESCRIPTION
Previously, we've identified that we can't actually get correct data due to misaligned struct fields between what is interpreted in kernel and userspace. Hutch will actually crash now due to the memory alignment issue (particularly when Hutch is interpreting pointers).

This PR applies a bandaid by attempting to insert a padding element. This PR does make some fundamental assumptions about how the compiler will layout memory and such. Effectively, the PR materializes the implicit padding field at the end of every nested/unrolled struct.

This bandaid ends up producing the following data for an `IndexOnlyScan`:
```
query_id,IndexOnlyScan_scan_plan_type,IndexOnlyScan_scan_plan_startup_cost,IndexOnlyScan_scan_plan_total_cost,IndexOnlyScan_scan_plan_plan_rows,IndexOnlyScan_scan_plan_plan_w    idth,IndexOnlyScan_scan_plan_parallel_aware,IndexOnlyScan_scan_plan_parallel_safe,IndexOnlyScan_scan_plan_async_capable,IndexOnlyScan_scan_plan_plan_node_id,IndexOnlyScan_sca    n_plan_targetlist,IndexOnlyScan_scan_plan_qual,IndexOnlyScan_scan_plan_initPlan,IndexOnlyScan_scan_scanrelid,IndexOnlyScan_indexid,IndexOnlyScan_indexqual,IndexOnlyScan_index    orderby,IndexOnlyScan_indextlist,IndexOnlyScan_indexorderdir,left_child_plan_node_id,right_child_plan_node_id,statement_timestamp,start_time,end_time,cpu_cycles,instructions,    cache_references,cache_misses,ref_cpu_cycles,network_bytes_read,network_bytes_written,disk_bytes_read,disk_bytes_written,memory_bytes,elapsed_us,pid,cpu_id
6342581062634470325,22,0.285,1.402,1.0,8,0,1,0,0,2,0,0,1,16389,1,0,2,1,-1,-1,700006131045767,319901914353,319901914369,67597,18817,1626,1335,46782,0,0,0,0,0,13,188644,8
```