### PR TITLE
Change Hutch's GetNodeType for HashJoin

### DIFF
--- a/cmudb/extensions/hutch/main.c
+++ b/cmudb/extensions/hutch/main.c
@@ -199,7 +199,7 @@ static const char *GetNodeType(Plan *node) {
       sname = "MergeJoin";
       break;
     case T_HashJoin:
-      sname = "HashJoin";
+      sname = "HashJoinImpl";
       break;
     case T_SeqScan:
       sname = "SeqScan";


### PR DESCRIPTION
Previously, `Hutch`'s `GetNodeType` was returning `HashJoin`. Instead we want to return `HashJoinImpl`.
(`HashJoinImpl` is how the OU is referenced throughout the rest of the pipeline).