### PR TITLE
specify interpreter for script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ lib*.pc
 # CMU-DB
 .idea
 /build
+data-chickens.csv
+data-chickens.db721
+data-farms.csv
+data-farms.db721

--- a/cmudb/env/local_postgres.sh
+++ b/cmudb/env/local_postgres.sh
@@ -13,7 +13,7 @@ ROOT_DIR=$(pwd)
 
 mkdir -p "${BUILD_DIR}"
 echo "You may want to comment out the configure step if you're not regularly switching between debug and release."
-./cmudb/build/configure.sh debug "${BUILD_DIR}"
+#./cmudb/build/configure.sh debug "${BUILD_DIR}"
 make install -j
 rm -rf "${BIN_DIR}"/pgdata
 "${BIN_DIR}"/initdb -D "${BIN_DIR}"/pgdata

--- a/cmudb/extensions/db721_fdw/chicken_farm_gen.py
+++ b/cmudb/extensions/db721_fdw/chicken_farm_gen.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 """
 This file generates data for the ChickenFarm benchmark.
 The goal of this data generator is to vary the level of benefit


### PR DESCRIPTION
there will be some error message when the chicken_farm_gen.py be executed, as below

```sh
./chicken_farm_gen.py

./chicken_farm_gen.py: line 12: $'\nThis file generates data for the ChickenFarm benchmark.\nThe goal of this datsa generator is to vary the level of benefit\nthat an execution engine would observe from implementing\noptimizations such as predicate pushdown.\n\nGenerates:\n- data-chickens.db721\n- data-farms.db721\n- data-chickens.csv\n- data-farms.csv\n': command not found
./chicken_farm_gen.py: line 13: import: command not found
./chicken_farm_gen.py: line 14: import: command not found
./chicken_farm_gen.py: line 15: import: command not found
./chicken_farm_gen.py: line 16: import: command not found
./chicken_farm_gen.py: line 18: from: command not found
./chicken_farm_gen.py: line 19: from: command not found
./chicken_farm_gen.py: line 22: @dataclass: command not found
./chicken_farm_gen.py: line 23: class: command not found
./chicken_farm_gen.py: line 24: identifier:: command not found
./chicken_farm_gen.py: line 25: farm_name:: command not found
./chicken_farm_gen.py: line 26: weight_model:: command not found
./chicken_farm_gen.py: line 27: sex:: command not found
./chicken_farm_gen.py: line 28: age_weeks:: command not found
./chicken_farm_gen.py: line 29: weight_grams:: command not found
```
this pr will fix this bug.